### PR TITLE
feat(core): intercept OSC 133/7 shell-integration marks (TREK-164)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cc",
  "jni",
  "libc",
@@ -217,9 +217,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arboard"
@@ -249,9 +249,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bit-set"
@@ -471,9 +471,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block2"
@@ -508,19 +508,19 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -560,7 +560,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -621,14 +621,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 1.3.0",
+ "shlex",
 ]
 
 [[package]]
@@ -913,9 +913,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_builder"
@@ -960,7 +957,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
 ]
 
@@ -996,9 +993,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -1328,15 +1325,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1391,7 +1386,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -1402,7 +1397,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1439,20 +1434,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1471,12 +1460,6 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1505,18 +1488,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -1615,13 +1596,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1644,9 +1624,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1654,11 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -1667,12 +1647,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1698,14 +1672,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -1737,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -1747,7 +1721,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1780,15 +1754,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1814,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1866,13 +1840,13 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -1896,7 +1870,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -1926,7 +1900,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1957,7 +1931,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1971,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2083,7 +2057,7 @@ dependencies = [
  "oakterm-pty",
  "oakterm-terminal",
  "rustix 1.1.4",
- "shlex 2.0.1",
+ "shlex",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -2176,7 +2150,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2192,7 +2166,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
@@ -2204,7 +2178,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2228,7 +2202,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2240,7 +2214,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -2251,7 +2225,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "libc",
@@ -2291,7 +2265,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2310,7 +2284,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -2323,7 +2297,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2334,7 +2308,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2357,7 +2331,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2369,7 +2343,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -2381,7 +2355,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2394,7 +2368,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -2421,7 +2395,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -2453,7 +2427,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2474,9 +2448,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "orbclient"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
@@ -2600,18 +2574,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2681,7 +2655,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2748,16 +2722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "pxfm"
@@ -2795,9 +2759,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -2805,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2870,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -2893,16 +2857,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2987,7 +2951,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3000,7 +2964,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3122,12 +3086,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -3166,15 +3124,15 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -3197,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3207,7 +3165,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -3237,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3251,7 +3209,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3285,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3301,7 +3259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3381,12 +3339,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3398,15 +3355,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3514,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3622,21 +3579,15 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3646,9 +3597,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -3714,7 +3665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "log",
  "memchr",
@@ -3738,27 +3689,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3769,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3779,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3789,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3802,45 +3744,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3863,7 +3771,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -3875,7 +3783,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -3893,11 +3801,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -3909,7 +3817,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3922,7 +3830,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3954,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3985,7 +3893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -4010,14 +3918,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -4043,42 +3951,42 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
  "cfg-if",
@@ -4119,13 +4027,14 @@ dependencies = [
  "wgpu-types",
  "windows",
  "windows-core",
+ "windows-result",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -4133,11 +4042,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -4147,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]
@@ -4469,7 +4378,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop",
@@ -4514,20 +4423,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -4535,85 +4435,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "x11-dl"
@@ -4659,7 +4480,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -4686,9 +4507,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -4745,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4789,18 +4610,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4858,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.1"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4872,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.1"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4885,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/oakterm-daemon/src/server.rs
+++ b/crates/oakterm-daemon/src/server.rs
@@ -1872,6 +1872,32 @@ mod tests {
     }
 
     #[test]
+    fn osc_133_prompt_marks_reach_scrollback_and_are_found() {
+        // End-to-end: an OSC 133;A prompt fed through the VT parser must be
+        // decoded onto its row, scroll into the hot buffer, and be locatable
+        // by find_prompt_in_buffer — the path scroll-to-prompt depends on.
+        use oakterm_terminal::grid::ScreenSet;
+
+        let mut ss = ScreenSet::new(80, 3);
+        let mut sink = Vec::new();
+        ss.process_bytes(b"\x1b]133;A\x07prompt$ \r\n", &mut sink);
+        // Scroll the marked prompt row off the top into scrollback.
+        for _ in 0..5 {
+            ss.process_bytes(b"output line\r\n", &mut sink);
+        }
+
+        assert!(
+            !ss.scrollback().is_empty(),
+            "prompt row should have scrolled into the hot buffer"
+        );
+        let found = find_prompt_in_buffer(ss.scrollback(), 0, SearchDirection::Older);
+        assert!(
+            found.is_some(),
+            "find_prompt_in_buffer should locate the decoded OSC 133;A mark"
+        );
+    }
+
+    #[test]
     fn build_command_spec_empty_command_default_shell() {
         let spec = build_command_spec("", "").expect("default spec");
         assert!(spec.program.is_none());

--- a/crates/oakterm-terminal/benches/vt_parser.rs
+++ b/crates/oakterm-terminal/benches/vt_parser.rs
@@ -1,5 +1,5 @@
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use oakterm_terminal::grid::Grid;
+use oakterm_terminal::grid::{Grid, ScreenSet};
 use oakterm_terminal::handler::process_bytes;
 
 /// 10 KB of printable ASCII ('A'-'z') mixed with newlines every ~72 chars.
@@ -81,6 +81,64 @@ fn make_scrolling() -> Vec<u8> {
     buf
 }
 
+/// Realistic shell session: each command is bracketed by OSC 133 marks
+/// (A prompt, B input, C output, D exit) with an OSC 7 cwd update, so the
+/// shell-integration scanner runs against the density it sees in practice.
+fn make_shell_session() -> Vec<u8> {
+    let mut buf = Vec::with_capacity(10 * 1024);
+    let mut n = 0u32;
+    loop {
+        let mut chunk = Vec::new();
+        chunk.extend_from_slice(b"\x1b]7;file://host/home/user/project\x07");
+        chunk.extend_from_slice(b"\x1b]133;A\x07user@host:~/project$ ");
+        chunk.extend_from_slice(b"\x1b]133;B\x07");
+        let cmd = format!("cargo build --bin app_{n}\r\n");
+        chunk.extend_from_slice(cmd.as_bytes());
+        chunk.extend_from_slice(b"\x1b]133;C\x07");
+        chunk.extend_from_slice(b"   Compiling app v0.1.0\r\n    Finished in 1.2s\r\n");
+        chunk.extend_from_slice(b"\x1b]133;D;0\x07");
+        if buf.len() + chunk.len() > 10 * 1024 {
+            break;
+        }
+        buf.extend_from_slice(&chunk);
+        n += 1;
+    }
+    buf
+}
+
+/// Plain output through the `ScreenSet` path, which runs the OSC 7/133 scanner
+/// over every byte. Guards against scanner overhead on the common case where
+/// PTY output carries no shell-integration marks.
+fn bench_screenset_plain_ascii(c: &mut Criterion) {
+    let data = make_plain_ascii();
+    let mut group = c.benchmark_group("shell_integration");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+    group.bench_function("screenset_plain_ascii", |b| {
+        b.iter_batched(
+            || ScreenSet::new(80, 24),
+            |mut ss| ss.process_bytes(&data, &mut std::io::sink()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+/// Shell-integration-heavy stream through the `ScreenSet` path, exercising the
+/// scanner's OSC 7/133 decode and mark-attachment on realistic prompt density.
+fn bench_screenset_shell_session(c: &mut Criterion) {
+    let data = make_shell_session();
+    let mut group = c.benchmark_group("shell_integration");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+    group.bench_function("screenset_shell_session", |b| {
+        b.iter_batched(
+            || ScreenSet::new(80, 24),
+            |mut ss| ss.process_bytes(&data, &mut std::io::sink()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
 fn bench_plain_ascii(c: &mut Criterion) {
     let data = make_plain_ascii();
     let mut group = c.benchmark_group("vt_parser");
@@ -142,6 +200,8 @@ criterion_group!(
     bench_plain_ascii,
     bench_sgr_color,
     bench_mixed_realistic,
-    bench_scrolling
+    bench_scrolling,
+    bench_screenset_plain_ascii,
+    bench_screenset_shell_session
 );
 criterion_main!(benches);

--- a/crates/oakterm-terminal/src/grid/mod.rs
+++ b/crates/oakterm-terminal/src/grid/mod.rs
@@ -281,6 +281,9 @@ pub struct ScreenSet {
     /// VT parser state, persisted across PTY read chunks to avoid
     /// mid-sequence splits that leak escape fragments as literal text.
     processor: vte::ansi::Processor<vte::ansi::StdSyncHandler>,
+    /// OSC 7/133 interceptor: vte does not dispatch these, so we decode them
+    /// alongside the processor and attach marks to the row the cursor lands on.
+    shell_scanner: crate::shell_integration::ShellIntegrationScanner,
 }
 
 impl ScreenSet {
@@ -294,6 +297,7 @@ impl ScreenSet {
             save_alternate_scrollback: false,
             archive: None,
             processor: vte::ansi::Processor::new(),
+            shell_scanner: crate::shell_integration::ShellIntegrationScanner::new(),
             search: None,
         }
     }
@@ -303,14 +307,58 @@ impl ScreenSet {
     /// The parser state is preserved across calls so escape sequences
     /// that span read chunk boundaries are handled correctly.
     pub fn process_bytes(&mut self, input: &[u8], writer: &mut impl std::io::Write) {
+        use crate::shell_integration::ScanStep;
+
         // Temporarily extract the processor to avoid a double mutable borrow
         // (self is borrowed by Terminal::new, processor by advance).
         let mut processor = std::mem::replace(&mut self.processor, vte::ansi::Processor::new());
-        {
-            let mut terminal = crate::handler::Terminal::new(self, writer);
-            processor.advance(&mut terminal, input);
+        // The scanner splits the chunk at OSC 7/133 terminators so each mark
+        // lands on the row the cursor occupies after all prior bytes render.
+        for step in self.shell_scanner.scan(input) {
+            match step {
+                ScanStep::Feed { start, end } => {
+                    let mut terminal = crate::handler::Terminal::new(self, writer);
+                    processor.advance(&mut terminal, &input[start..end]);
+                }
+                ScanStep::Mark(mark) => self.apply_shell_mark(&mark),
+            }
         }
         self.processor = processor;
+    }
+
+    /// Attach a decoded shell-integration mark to the active grid's cursor row
+    /// and bump its sequence number so the row ships on the next render update.
+    fn apply_shell_mark(&mut self, mark: &crate::shell_integration::ShellMark) {
+        use crate::grid::row::{MarkMetadata, SemanticMark};
+        use crate::shell_integration::ShellMark;
+
+        let g = self.active_grid_mut();
+        let row = g.cursor.row as usize;
+        if row >= g.lines.len() {
+            tracing::debug!(
+                row,
+                lines = g.lines.len(),
+                "shell mark dropped: cursor row out of bounds"
+            );
+            return;
+        }
+        let seqno = g.next_seqno();
+        let line = &mut g.lines[row];
+        match mark {
+            ShellMark::PromptStart => line.semantic_mark = SemanticMark::PromptStart,
+            ShellMark::InputStart => line.semantic_mark = SemanticMark::InputStart,
+            ShellMark::OutputStart => line.semantic_mark = SemanticMark::OutputStart,
+            ShellMark::CommandFinished(exit) => {
+                line.semantic_mark = SemanticMark::OutputEnd;
+                // Own this row's metadata: set the exit code, or clear any stale
+                // metadata (e.g. a prior cwd) when the D mark carries no code.
+                line.mark_metadata = exit.map(MarkMetadata::ExitCode);
+            }
+            ShellMark::WorkingDirectory(path) => {
+                line.mark_metadata = Some(MarkMetadata::WorkingDirectory(path.clone()));
+            }
+        }
+        line.seqno = seqno;
     }
 
     #[must_use]
@@ -456,6 +504,7 @@ impl ScreenSet {
         self.alternate = None;
         self.primary = Grid::new(cols, rows);
         self.processor = vte::ansi::Processor::new();
+        self.shell_scanner.reset();
     }
 
     /// Resize both primary and alternate grids (if allocated).

--- a/crates/oakterm-terminal/src/grid/mod.rs
+++ b/crates/oakterm-terminal/src/grid/mod.rs
@@ -358,6 +358,14 @@ impl ScreenSet {
                 line.mark_metadata = Some(MarkMetadata::WorkingDirectory(path.clone()));
             }
         }
+        // An ExitCode belongs to the finished command, so it may only coexist
+        // with an OutputEnd mark. If a later prompt/input/output-start lands on
+        // the same row, shed the stale exit code (but keep a WorkingDirectory).
+        if line.semantic_mark != SemanticMark::OutputEnd
+            && matches!(line.mark_metadata, Some(MarkMetadata::ExitCode(_)))
+        {
+            line.mark_metadata = None;
+        }
         line.seqno = seqno;
     }
 

--- a/crates/oakterm-terminal/src/grid/row.rs
+++ b/crates/oakterm-terminal/src/grid/row.rs
@@ -28,7 +28,9 @@ impl SemanticMark {
     }
 }
 
-/// Metadata attached to a semantic mark.
+/// Per-row shell-integration metadata. Independent of `semantic_mark`:
+/// `ExitCode` accompanies an `OutputEnd` mark, but `WorkingDirectory` (OSC 7)
+/// is recorded on its row with no semantic mark of its own.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MarkMetadata {
     ExitCode(i32),

--- a/crates/oakterm-terminal/src/grid/tests.rs
+++ b/crates/oakterm-terminal/src/grid/tests.rs
@@ -342,6 +342,28 @@ fn osc_133_d_without_exit_clears_stale_metadata() {
 }
 
 #[test]
+fn osc_133_prompt_sheds_stale_exit_code_but_keeps_cwd() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    // D;0 then A on the same row: the prompt mark must not inherit the exit code.
+    ss.process_bytes(b"\x1b]133;D;0\x07\x1b]133;A\x07", &mut sink);
+    let row = &ss.active_grid().lines[0];
+    assert_eq!(row.semantic_mark, SemanticMark::PromptStart);
+    assert_eq!(row.mark_metadata, None);
+
+    // OSC 7 then A on the same row: the cwd is orthogonal and must survive.
+    let mut ss2 = ScreenSet::new(80, 24);
+    let mut sink2 = Vec::new();
+    ss2.process_bytes(b"\x1b]7;file://h/tmp\x07\x1b]133;A\x07", &mut sink2);
+    let row2 = &ss2.active_grid().lines[0];
+    assert_eq!(row2.semantic_mark, SemanticMark::PromptStart);
+    assert_eq!(
+        row2.mark_metadata,
+        Some(MarkMetadata::WorkingDirectory("/tmp".into()))
+    );
+}
+
+#[test]
 fn osc_133_survives_read_chunk_split() {
     let mut ss = ScreenSet::new(80, 24);
     let mut sink = Vec::new();

--- a/crates/oakterm-terminal/src/grid/tests.rs
+++ b/crates/oakterm-terminal/src/grid/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use cell::{Cell, CellFlags, Color, NamedColor, UnderlineStyle, WideState};
 use cursor::CursorStyle;
-use row::{Direction, Row, RowFlags, SemanticMark};
+use row::{Direction, MarkMetadata, Row, RowFlags, SemanticMark};
 use selection::{AnchorSide, SelectionAnchor};
 
 #[test]
@@ -293,6 +293,76 @@ fn screen_set_reset_preserves_scrollback() {
     assert_eq!(ss.scrollback().len(), 2);
     ss.reset();
     assert_eq!(ss.scrollback().len(), 2, "scrollback should survive reset");
+}
+
+#[test]
+fn osc_133_prompt_marks_cursor_row() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    // "abc" + CRLF leaves the cursor on row 1; the mark must land there.
+    ss.process_bytes(b"abc\r\n\x1b]133;A\x07", &mut sink);
+    assert_eq!(ss.active_grid().lines[0].semantic_mark, SemanticMark::None);
+    assert_eq!(
+        ss.active_grid().lines[1].semantic_mark,
+        SemanticMark::PromptStart
+    );
+}
+
+#[test]
+fn osc_133_command_finished_carries_exit_code() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    ss.process_bytes(b"\x1b]133;D;7\x07", &mut sink);
+    let row = &ss.active_grid().lines[0];
+    assert_eq!(row.semantic_mark, SemanticMark::OutputEnd);
+    assert_eq!(row.mark_metadata, Some(MarkMetadata::ExitCode(7)));
+}
+
+#[test]
+fn osc_7_records_working_directory() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    ss.process_bytes(b"\x1b]7;file://myhost/home/user\x07", &mut sink);
+    assert_eq!(
+        ss.active_grid().lines[0].mark_metadata,
+        Some(MarkMetadata::WorkingDirectory("/home/user".into()))
+    );
+}
+
+#[test]
+fn osc_133_d_without_exit_clears_stale_metadata() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    // OSC 7 then OSC 133;D (no exit) on the same row: the D mark owns the
+    // metadata slot, so the stale cwd must not linger on the OutputEnd row.
+    ss.process_bytes(b"\x1b]7;file://h/tmp\x07\x1b]133;D\x07", &mut sink);
+    let row = &ss.active_grid().lines[0];
+    assert_eq!(row.semantic_mark, SemanticMark::OutputEnd);
+    assert_eq!(row.mark_metadata, None);
+}
+
+#[test]
+fn osc_133_survives_read_chunk_split() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    // The daemon reads PTY output in arbitrary chunks; a sequence split
+    // across two reads must still be decoded.
+    ss.process_bytes(b"\x1b]133;A", &mut sink);
+    ss.process_bytes(b"\x07", &mut sink);
+    assert_eq!(
+        ss.active_grid().lines[0].semantic_mark,
+        SemanticMark::PromptStart
+    );
+}
+
+#[test]
+fn osc_133_bumps_row_seqno_for_render() {
+    let mut ss = ScreenSet::new(80, 24);
+    let mut sink = Vec::new();
+    let before = ss.active_grid().seqno;
+    ss.process_bytes(b"\x1b]133;A\x07", &mut sink);
+    // The marked row must be reported dirty so the mark ships to the GUI.
+    assert!(ss.active_grid().lines[0].seqno > before);
 }
 
 #[test]

--- a/crates/oakterm-terminal/src/lib.rs
+++ b/crates/oakterm-terminal/src/lib.rs
@@ -2,6 +2,7 @@ pub mod grid;
 pub mod handler;
 pub mod scroll;
 pub mod search;
+pub mod shell_integration;
 
 #[cfg(test)]
 pub(crate) mod testing;

--- a/crates/oakterm-terminal/src/shell_integration.rs
+++ b/crates/oakterm-terminal/src/shell_integration.rs
@@ -1,0 +1,553 @@
+//! OSC 7 / OSC 133 interception.
+//!
+//! vte 0.15's `ansi::Handler` has no callbacks for OSC 133 (shell integration
+//! semantic marks) or OSC 7 (working directory): its `osc_dispatch` routes both
+//! to `unhandled()`. This scanner runs alongside the VT processor. It finds
+//! complete OSC 7/133 sequences in the byte stream and splits each read at the
+//! sequence terminator, so the caller can position the grid cursor — by feeding
+//! all prior bytes to the processor — before attaching the mark to the row the
+//! cursor lands on. Partial-sequence state persists across read chunks.
+//!
+//! Every byte is still fed to the VT processor unchanged; the OSC 7/133
+//! payloads reach vte and are dropped as `unhandled`. The scanner only injects
+//! mark events between the processor feeds — it never rewrites the stream.
+
+/// OSC payload cap, matching the Spec-0002 OSC buffer limit. Payloads longer
+/// than this are not decoded (the sequence still passes through to vte).
+const MAX_OSC: usize = 4096;
+
+/// A shell-integration event decoded from an OSC 7/133 sequence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellMark {
+    /// OSC 133;A — prompt start.
+    PromptStart,
+    /// OSC 133;B — command input start.
+    InputStart,
+    /// OSC 133;C — command output start.
+    OutputStart,
+    /// OSC 133;D — command finished, with optional exit code.
+    CommandFinished(Option<i32>),
+    /// OSC 7 — current working directory (decoded filesystem path).
+    WorkingDirectory(String),
+}
+
+/// One step in replaying a read chunk against the VT processor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanStep {
+    /// Feed `chunk[start..end]` to the VT processor.
+    Feed { start: usize, end: usize },
+    /// Attach this mark to the row the cursor is on, then continue.
+    Mark(ShellMark),
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum State {
+    #[default]
+    Ground,
+    /// Saw `ESC` in ground state.
+    Esc,
+    /// Inside an OSC payload.
+    Osc,
+    /// Saw `ESC` inside an OSC payload (potential ST terminator).
+    OscEsc,
+}
+
+/// Stateful scanner for OSC 7/133 sequences. One per terminal parser, reused
+/// across read chunks so sequences that span chunk boundaries are decoded.
+#[derive(Debug, Default)]
+pub struct ShellIntegrationScanner {
+    state: State,
+    /// Accumulated OSC payload, bounded by `MAX_OSC`.
+    buf: Vec<u8>,
+    /// The current payload exceeded `MAX_OSC`; stop decoding it.
+    overflowed: bool,
+}
+
+impl ShellIntegrationScanner {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clear all state, including any partial in-flight sequence. Called on RIS.
+    pub fn reset(&mut self) {
+        self.state = State::Ground;
+        self.buf.clear();
+        self.overflowed = false;
+    }
+
+    /// Scan a read chunk, returning the interleaved feed/mark steps to replay
+    /// against the VT processor. `Feed` ranges cover the whole chunk in order
+    /// with no gaps or overlaps; `Mark` steps are injected at OSC terminators.
+    #[must_use]
+    pub fn scan(&mut self, chunk: &[u8]) -> Vec<ScanStep> {
+        let mut steps = Vec::new();
+        let mut seg_start = 0usize;
+
+        for (i, &b) in chunk.iter().enumerate() {
+            match self.state {
+                State::Ground => {
+                    if b == 0x1b {
+                        self.state = State::Esc;
+                    }
+                }
+                State::Esc => match b {
+                    0x5d => {
+                        self.state = State::Osc;
+                        self.buf.clear();
+                        self.overflowed = false;
+                    }
+                    0x1b => {}
+                    _ => self.state = State::Ground,
+                },
+                State::Osc => match b {
+                    0x07 => self.terminate(i, &mut seg_start, &mut steps),
+                    // CAN/SUB cancel the sequence (vte aborts string controls on
+                    // these); abort without decoding so no false mark is emitted.
+                    0x18 | 0x1a => self.abort_osc(),
+                    0x1b => self.state = State::OscEsc,
+                    _ => self.push_byte(b),
+                },
+                State::OscEsc => match b {
+                    0x5c => self.terminate(i, &mut seg_start, &mut steps),
+                    0x1b => {
+                        self.buf.clear();
+                        self.overflowed = false;
+                        self.state = State::Esc;
+                    }
+                    _ => self.abort_osc(),
+                },
+            }
+        }
+
+        if seg_start < chunk.len() {
+            steps.push(ScanStep::Feed {
+                start: seg_start,
+                end: chunk.len(),
+            });
+        }
+        steps
+    }
+
+    /// Handle an OSC terminator at index `end` (BEL) or the `\` of an ST.
+    /// Emits a feed-through-terminator + mark pair only when the payload
+    /// decodes to an intercepted mark; otherwise the bytes stay in the
+    /// pending segment and pass through with the next feed.
+    fn terminate(&mut self, end: usize, seg_start: &mut usize, steps: &mut Vec<ScanStep>) {
+        if let Some(mark) = self.decode() {
+            steps.push(ScanStep::Feed {
+                start: *seg_start,
+                end: end + 1,
+            });
+            steps.push(ScanStep::Mark(mark));
+            *seg_start = end + 1;
+        }
+        self.buf.clear();
+        self.overflowed = false;
+        self.state = State::Ground;
+    }
+
+    /// Abandon the in-flight OSC payload without decoding it and return to
+    /// ground. Used for CAN/SUB cancellation and malformed ESC sequences.
+    fn abort_osc(&mut self) {
+        self.buf.clear();
+        self.overflowed = false;
+        self.state = State::Ground;
+    }
+
+    fn push_byte(&mut self, b: u8) {
+        if self.overflowed {
+            return;
+        }
+        if self.buf.len() >= MAX_OSC {
+            self.overflowed = true;
+            tracing::debug!(cap = MAX_OSC, "OSC payload exceeded cap; not decoded");
+            return;
+        }
+        self.buf.push(b);
+    }
+
+    /// Decode the accumulated payload into a mark, if it is an OSC 7 or 133
+    /// sequence we intercept. Returns `None` for any other OSC code.
+    fn decode(&self) -> Option<ShellMark> {
+        if self.overflowed {
+            return None;
+        }
+        let (code, rest) = split_once(&self.buf, b';');
+        match code {
+            b"133" => decode_133(rest),
+            b"7" => decode_osc7(rest),
+            _ => None,
+        }
+    }
+}
+
+/// OSC 133;`<letter>`[;`<params>`] → semantic mark.
+fn decode_133(rest: &[u8]) -> Option<ShellMark> {
+    let (letter, params) = split_once(rest, b';');
+    match letter {
+        b"A" => Some(ShellMark::PromptStart),
+        b"B" => Some(ShellMark::InputStart),
+        b"C" => Some(ShellMark::OutputStart),
+        b"D" => Some(ShellMark::CommandFinished(parse_exit_code(params))),
+        _ => None,
+    }
+}
+
+/// The exit code in `OSC 133;D;<code>` is the first `;`-delimited field after
+/// `D`. Absent or non-numeric fields yield `None` (command finished, status
+/// unknown).
+fn parse_exit_code(params: &[u8]) -> Option<i32> {
+    let (field, _) = split_once(params, b';');
+    if field.is_empty() {
+        return None;
+    }
+    std::str::from_utf8(field).ok()?.trim().parse::<i32>().ok()
+}
+
+/// OSC 7;`file://<host>/<path>` → working directory. The path is the URI
+/// component after the authority, percent-decoded. A non-`file://` scheme,
+/// non-UTF-8 payload, or empty path yields `None` so live cwd keeps its last
+/// known value rather than adopting a meaningless one.
+fn decode_osc7(rest: &[u8]) -> Option<ShellMark> {
+    let Ok(uri) = std::str::from_utf8(rest) else {
+        tracing::debug!(len = rest.len(), "OSC 7 payload not UTF-8; cwd unchanged");
+        return None;
+    };
+    let Some(after) = uri.strip_prefix("file://") else {
+        tracing::debug!(uri, "OSC 7 payload missing file:// scheme; cwd unchanged");
+        return None;
+    };
+    let path_start = after.find('/').unwrap_or(after.len());
+    let path = percent_decode(&after[path_start..]);
+    if path.is_empty() {
+        tracing::debug!(uri, "OSC 7 has empty path; cwd unchanged");
+        return None;
+    }
+    Some(ShellMark::WorkingDirectory(path))
+}
+
+/// When `sep` is absent, `after` is empty.
+fn split_once(buf: &[u8], sep: u8) -> (&[u8], &[u8]) {
+    match buf.iter().position(|&c| c == sep) {
+        Some(p) => (&buf[..p], &buf[p + 1..]),
+        None => (buf, &[]),
+    }
+}
+
+/// Invalid escapes are left verbatim; the decoded bytes are interpreted as
+/// UTF-8 (lossily, to tolerate exotic filesystems).
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push(hi * 16 + lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run a full byte stream through the scanner, returning just the decoded
+    /// marks (feed ranges are asserted separately where they matter).
+    fn marks(chunks: &[&[u8]]) -> Vec<ShellMark> {
+        let mut scanner = ShellIntegrationScanner::new();
+        let mut out = Vec::new();
+        for chunk in chunks {
+            for step in scanner.scan(chunk) {
+                if let ScanStep::Mark(m) = step {
+                    out.push(m);
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn osc_133_a_bel_terminated() {
+        assert_eq!(marks(&[b"\x1b]133;A\x07"]), vec![ShellMark::PromptStart]);
+    }
+
+    #[test]
+    fn osc_133_a_st_terminated() {
+        assert_eq!(marks(&[b"\x1b]133;A\x1b\\"]), vec![ShellMark::PromptStart]);
+    }
+
+    #[test]
+    fn osc_133_all_variants() {
+        assert_eq!(marks(&[b"\x1b]133;B\x07"]), vec![ShellMark::InputStart]);
+        assert_eq!(marks(&[b"\x1b]133;C\x07"]), vec![ShellMark::OutputStart]);
+        assert_eq!(
+            marks(&[b"\x1b]133;D\x07"]),
+            vec![ShellMark::CommandFinished(None)]
+        );
+    }
+
+    #[test]
+    fn osc_133_d_with_exit_code() {
+        assert_eq!(
+            marks(&[b"\x1b]133;D;0\x07"]),
+            vec![ShellMark::CommandFinished(Some(0))]
+        );
+        assert_eq!(
+            marks(&[b"\x1b]133;D;130\x07"]),
+            vec![ShellMark::CommandFinished(Some(130))]
+        );
+    }
+
+    #[test]
+    fn osc_133_d_trailing_params_after_exit_code() {
+        assert_eq!(
+            marks(&[b"\x1b]133;D;1;aid=7\x07"]),
+            vec![ShellMark::CommandFinished(Some(1))]
+        );
+    }
+
+    #[test]
+    fn osc_133_a_with_extra_params_ignored() {
+        assert_eq!(
+            marks(&[b"\x1b]133;A;aid=42\x07"]),
+            vec![ShellMark::PromptStart]
+        );
+    }
+
+    #[test]
+    fn osc_7_absolute_path() {
+        assert_eq!(
+            marks(&[b"\x1b]7;file://host/home/jace\x07"]),
+            vec![ShellMark::WorkingDirectory("/home/jace".into())]
+        );
+    }
+
+    #[test]
+    fn osc_7_empty_host() {
+        assert_eq!(
+            marks(&[b"\x1b]7;file:///var/log\x07"]),
+            vec![ShellMark::WorkingDirectory("/var/log".into())]
+        );
+    }
+
+    #[test]
+    fn osc_7_percent_decoded() {
+        assert_eq!(
+            marks(&[b"\x1b]7;file://host/my%20dir/a%2Bb\x07"]),
+            vec![ShellMark::WorkingDirectory("/my dir/a+b".into())]
+        );
+    }
+
+    #[test]
+    fn osc_1337_not_confused_with_133() {
+        // iTerm2 proprietary OSC 1337 must not be decoded as OSC 133.
+        assert_eq!(marks(&[b"\x1b]1337;SetMark\x07"]), vec![]);
+    }
+
+    #[test]
+    fn osc_70_not_confused_with_7() {
+        assert_eq!(marks(&[b"\x1b]70;something\x07"]), vec![]);
+    }
+
+    #[test]
+    fn unrelated_osc_ignored() {
+        // OSC 0 (title) and OSC 8 (hyperlink) produce no marks.
+        assert_eq!(marks(&[b"\x1b]0;my title\x07"]), vec![]);
+        assert_eq!(
+            marks(&[b"\x1b]8;;https://example.com\x07link\x1b]8;;\x07"]),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn split_across_chunks() {
+        assert_eq!(
+            marks(&[b"\x1b]133", b";A\x07"]),
+            vec![ShellMark::PromptStart]
+        );
+        assert_eq!(
+            marks(&[b"\x1b]7;file://h/a", b"/b\x07"]),
+            vec![ShellMark::WorkingDirectory("/a/b".into())]
+        );
+    }
+
+    #[test]
+    fn st_terminator_split_across_chunks() {
+        assert_eq!(
+            marks(&[b"\x1b]133;A\x1b", b"\\"]),
+            vec![ShellMark::PromptStart]
+        );
+    }
+
+    #[test]
+    fn multiple_marks_in_one_chunk() {
+        assert_eq!(
+            marks(&[b"\x1b]133;A\x07prompt\x1b]133;B\x07"]),
+            vec![ShellMark::PromptStart, ShellMark::InputStart]
+        );
+    }
+
+    #[test]
+    fn feed_ranges_cover_chunk_without_gaps() {
+        let mut scanner = ShellIntegrationScanner::new();
+        let chunk = b"ab\x1b]133;A\x07cd";
+        let steps = scanner.scan(chunk);
+        // Reassemble the fed bytes; they must equal the whole chunk in order.
+        let mut reassembled = Vec::new();
+        for step in &steps {
+            if let ScanStep::Feed { start, end } = step {
+                reassembled.extend_from_slice(&chunk[*start..*end]);
+            }
+        }
+        assert_eq!(reassembled, chunk);
+        assert!(steps.iter().any(|s| matches!(s, ScanStep::Mark(_))));
+    }
+
+    #[test]
+    fn mark_injected_after_terminator() {
+        let mut scanner = ShellIntegrationScanner::new();
+        let steps = scanner.scan(b"\x1b]133;A\x07x");
+        // Order: feed through the BEL, then the mark, then feed the tail.
+        assert_eq!(
+            steps,
+            vec![
+                ScanStep::Feed { start: 0, end: 8 },
+                ScanStep::Mark(ShellMark::PromptStart),
+                ScanStep::Feed { start: 8, end: 9 },
+            ]
+        );
+    }
+
+    #[test]
+    fn oversized_payload_not_decoded() {
+        let mut seq = Vec::from(*b"\x1b]7;file://host/");
+        seq.extend(std::iter::repeat_n(b'a', MAX_OSC + 10));
+        seq.push(0x07);
+        assert_eq!(marks(&[&seq]), vec![]);
+    }
+
+    #[test]
+    fn reset_clears_partial_sequence() {
+        let mut scanner = ShellIntegrationScanner::new();
+        let _ = scanner.scan(b"\x1b]133;A"); // partial, no terminator
+        scanner.reset();
+        // The dangling terminator must not complete the abandoned sequence.
+        let steps = scanner.scan(b"\x07");
+        assert!(steps.iter().all(|s| !matches!(s, ScanStep::Mark(_))));
+    }
+
+    #[test]
+    fn no_osc_is_single_feed() {
+        let mut scanner = ShellIntegrationScanner::new();
+        assert_eq!(
+            scanner.scan(b"plain text"),
+            vec![ScanStep::Feed { start: 0, end: 10 }]
+        );
+    }
+
+    #[test]
+    fn scanner_recovers_after_oversized_payload() {
+        // An oversized OSC must not poison the scanner for subsequent marks.
+        let mut scanner = ShellIntegrationScanner::new();
+        let mut big = Vec::from(*b"\x1b]0;");
+        big.extend(std::iter::repeat_n(b'x', MAX_OSC + 10));
+        big.push(0x07);
+        let _ = scanner.scan(&big);
+        let mut out = Vec::new();
+        for step in scanner.scan(b"\x1b]133;A\x07") {
+            if let ScanStep::Mark(m) = step {
+                out.push(m);
+            }
+        }
+        assert_eq!(out, vec![ShellMark::PromptStart]);
+    }
+
+    #[test]
+    fn can_cancels_osc_without_emitting_mark() {
+        // CAN mid-payload aborts; the following real sequence still decodes.
+        assert_eq!(
+            marks(&[b"\x1b]133;A\x18\x1b]133;B\x07"]),
+            vec![ShellMark::InputStart]
+        );
+    }
+
+    #[test]
+    fn sub_cancels_osc_without_emitting_mark() {
+        assert_eq!(marks(&[b"\x1b]133;A\x1a\x07"]), vec![]);
+    }
+
+    #[test]
+    fn esc_inside_osc_aborts_then_next_sequence_decodes() {
+        // ESC followed by a non-ST byte aborts the current OSC; the subsequent
+        // OSC 133;A must still be found.
+        assert_eq!(
+            marks(&[b"\x1b]0;title\x1bX\x1b]133;A\x07"]),
+            vec![ShellMark::PromptStart]
+        );
+    }
+
+    #[test]
+    fn exit_code_non_numeric_is_none() {
+        assert_eq!(
+            marks(&[b"\x1b]133;D;abc\x07"]),
+            vec![ShellMark::CommandFinished(None)]
+        );
+        assert_eq!(
+            marks(&[b"\x1b]133;D;\x07"]),
+            vec![ShellMark::CommandFinished(None)]
+        );
+    }
+
+    #[test]
+    fn osc_7_non_file_scheme_ignored() {
+        assert_eq!(marks(&[b"\x1b]7;http://host/x\x07"]), vec![]);
+    }
+
+    #[test]
+    fn osc_7_empty_path_ignored() {
+        // `file://host` with no path component carries no usable cwd.
+        assert_eq!(marks(&[b"\x1b]7;file://host\x07"]), vec![]);
+    }
+
+    #[test]
+    fn percent_decode_invalid_escape_left_verbatim() {
+        assert_eq!(
+            marks(&[b"\x1b]7;file://h/a%zzb\x07"]),
+            vec![ShellMark::WorkingDirectory("/a%zzb".into())]
+        );
+        // A truncated `%2` at the end is preserved rather than dropped.
+        assert_eq!(
+            marks(&[b"\x1b]7;file://h/dir%2\x07"]),
+            vec![ShellMark::WorkingDirectory("/dir%2".into())]
+        );
+    }
+
+    #[test]
+    fn percent_decode_invalid_utf8_is_lossy() {
+        // `%ff` decodes to a byte that is not valid UTF-8; it becomes U+FFFD
+        // rather than dropping the mark.
+        let marks = marks(&[b"\x1b]7;file://h/a%ffb\x07"]);
+        assert_eq!(marks.len(), 1);
+        let ShellMark::WorkingDirectory(path) = &marks[0] else {
+            panic!("expected WorkingDirectory");
+        };
+        assert!(path.starts_with("/a") && path.ends_with('b') && path.contains('\u{fffd}'));
+    }
+}

--- a/docs/specs/0002-vt-parser.md
+++ b/docs/specs/0002-vt-parser.md
@@ -313,24 +313,36 @@ fn substitute(&mut self);       // SUB: 0x1A (print replacement char)
 
 #### Shell Integration (ADR-0008)
 
-```rust
-/// OSC 133;A — prompt start. Marks current row with SemanticMark::PromptStart.
-/// Raw parameter string preserved for future use (e.g., iTerm2's `aid=` parameter).
-fn shell_prompt_start(&mut self, raw_params: &str);
+OSC 133 and OSC 7 are **not dispatched by vte 0.15's `ansi::Handler`**: its
+`osc_dispatch` routes both to `unhandled()`, and no newer vte release adds a
+callback. They are instead decoded by a dedicated interceptor
+(`ShellIntegrationScanner`) that runs alongside the VT processor at the
+`ScreenSet` boundary. The scanner finds complete OSC 7/133 sequences in the PTY
+byte stream, persisting partial-sequence state across read chunks, and splits
+each read at the sequence terminator so the mark attaches to the row the cursor
+occupies once all prior bytes have rendered. Every byte still reaches vte
+unchanged; the scanner only injects mark events between the processor feeds.
 
-/// OSC 133;B — input start. Marks current row with SemanticMark::InputStart.
-fn shell_input_start(&mut self);
+Decoded sequences map to the following row mutations:
 
-/// OSC 133;C — command output start. Marks current row with SemanticMark::OutputStart.
-fn shell_output_start(&mut self);
+| Sequence             | `SemanticMark`    | `MarkMetadata`                |
+| -------------------- | ----------------- | ----------------------------- |
+| `OSC 133;A`          | `PromptStart`     | —                             |
+| `OSC 133;B`          | `InputStart`      | —                             |
+| `OSC 133;C`          | `OutputStart`     | —                             |
+| `OSC 133;D[;<exit>]` | `OutputEnd`       | `ExitCode(<exit>)` if present |
+| `OSC 7;file://…`     | — (metadata only) | `WorkingDirectory(<path>)`    |
 
-/// OSC 133;D — command finished. Marks current row with SemanticMark::OutputEnd.
-/// `exit_code` is None if not provided.
-fn shell_command_finished(&mut self, exit_code: Option<i32>);
+`OSC 133;D` exit code is the first `;`-delimited field after `D`; absent or
+non-numeric fields yield no `ExitCode`. `OSC 7` paths are the URI component
+after the authority, percent-decoded (the hostname is dropped in Phase 0). An
+empty path is ignored. Trailing parameters on `133;A` (e.g. iTerm2's `aid=`)
+are ignored in Phase 0.
 
-/// OSC 7 — current working directory.
-fn set_working_directory(&mut self, uri: &str);
-```
+A row holds a single `mark_metadata` slot, so if an `OSC 7` cwd and an
+`OSC 133;D` exit code land on the same row the later write wins (in practice
+they occupy different rows: cwd at prompt time, `D` at command end). This
+mirrors the single-`semantic_mark` collision noted in ADR-0015.
 
 #### Kitty Graphics (ADR-0004)
 


### PR DESCRIPTION
## Summary

Wires OSC 133 (shell-integration semantic marks) and OSC 7 (working directory) into the terminal, completing the last remaining task in EPIC-5 (Phase 0.4). The data layer for these marks already existed (`Row.semantic_mark`/`mark_metadata`, wire + archive serialization, `find_prompt_in_buffer`) but was always `None` in production because nothing set the marks.

**Root cause:** vte 0.15.0 (verified latest — no newer release) has no `ansi::Handler` callback for OSC 133/7; its internal `osc_dispatch` routes both to `unhandled()`. Confirmed against the vendored vte source. So we intercept rather than rely on a handler hook (Scope option 3).

## Approach

New `ShellIntegrationScanner` (`crates/oakterm-terminal/src/shell_integration.rs`) runs alongside the VT processor at the `ScreenSet::process_bytes` boundary:

- Byte-level OSC state machine that finds complete OSC 7/133 sequences (BEL or ST terminated), **persisting partial-sequence state across PTY read chunks**.
- Honors CAN/SUB cancellation and caps payloads at `MAX_OSC` (4096).
- Splits each read at the OSC terminator so a mark attaches to the row the cursor occupies **after prior bytes render** — every byte still reaches vte unchanged.

Decoding → row mutations:

| Sequence | `SemanticMark` | `MarkMetadata` |
| --- | --- | --- |
| `133;A` / `B` / `C` | PromptStart / InputStart / OutputStart | — |
| `133;D[;<exit>]` | OutputEnd | `ExitCode` if present |
| `7;file://host/path` | — | `WorkingDirectory` (percent-decoded; host dropped) |

Correctly disambiguates `7` vs `70` and `133` vs `1337`.

## Testing

- 29 scanner unit tests (chunk splits, BEL/ST terminators, CAN/SUB, overflow recovery, percent-decode edge cases, lossy UTF-8, code disambiguation).
- 6 `ScreenSet` integration tests (cursor-row timing, exit-code metadata, cwd, cross-read-chunk split, dirty seqno, stale-metadata clearing).
- End-to-end daemon test: `OSC 133;A` → scrollback → `find_prompt_in_buffer`.
- Benchmarks added for the every-byte hot path: `screenset_plain_ascii` (~111 MiB/s, above the 100 MB/s ground-state target) and `screenset_shell_session`.
- `mise run check` (fmt + clippy-pedantic + md-lint) and full `mise run test` green.

## Review

Ran the full multi-agent review cycle (Codex + code/test/silent-failure/type-design + maintainability + spec-conformance), 2 iterations. Fixes applied inline: CAN/SUB cancellation, stale-metadata clearing on bare `133;D`, logging breadcrumbs on cwd drop paths, bounds-check ordering. Spec-conformance verdict: faithful to ADR-0008 Phase 0, data-layer boundary respected.

## Follow-ups (tracked, out of scope here)

- **TREK-165** — `Row` multi-mark data model (a row can only hold one mark / one metadata slot today; needed for Phase 1 command-blocks per ADR-0015).
- **TREK-134** (CMT-111) — OSC 7 cwd now lives as row metadata; hostname is dropped.

Closes TREK-164.

https://claude.ai/code/session_013Lw1gM3artqQ2MStk5UhwA