### PR TITLE
docs: 2026 choices-audit housekeeping — positioning, foundational-stack ADRs, status reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 GPU-accelerated, extensible terminal emulator with a plugin-driven process dashboard and context-aware shell.
 
-**Status: Phase 0 Implementation** — core terminal foundation (renderer, VT parser, screen buffer).
+**Status: Phase 1** — Phase 0 terminal foundation (renderer, VT parser, screen buffer, daemon/client split) complete; the multiplexer is the next roadmap focus.
 
 ## Pipeline
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The terminal is the oldest developer tool that still works. It doesn't need to b
 - Zero telemetry. No login. No account. No phoning home. Ever.
 - AI features are opt-in, BYOK, and work with local models.
 - Open protocols — Kitty graphics, standard escape sequences, WASM plugins.
-- Platform-native — AppKit on macOS, GTK on Linux, WinUI on Windows. All three from day one. Not Electron.
-- Replaces tmux, not complements it.
+- Platform-native, never Electron — AppKit on macOS, GTK on Linux, WinUI on Windows. macOS and Linux ship first; Windows follows.
+- Built-in multiplexer — you won't need tmux or Zellij, but they coexist cleanly if you do.
 - Memory-conscious — tiered scroll buffer, per-pane budgets, no pre-allocation.
 - MPL 2.0 licensed — core stays open source, plugins can be any license.
 
@@ -77,7 +77,7 @@ Ideas explore possibilities. ADRs resolve questions that ideas surface. Specs fo
 | [Accessibility](docs/ideas/17-accessibility.md)         | AccessKit, screen reader, color blindness, extensible a11y API     |
 | [Theming](docs/ideas/22-theming.md)                     | Deep customization, TOML format, inheritance, live preview         |
 | [Internationalization](docs/ideas/23-i18n.md)           | Unicode rendering, locale packs via plugins                        |
-| [Platform Support](docs/ideas/20-platform-support.md)   | macOS, Linux, Windows — all first-class                            |
+| [Platform Support](docs/ideas/20-platform-support.md)   | macOS + Linux first-class; Windows following                       |
 | [Updates](docs/ideas/24-updates.md)                     | Every update path works, staged updates, rollback                  |
 | [Testing](docs/ideas/25-testing.md)                     | Unit, integration, platform, perf, security, a11y, VT compliance   |
 | [License](docs/ideas/26-license.md)                     | MPL 2.0 — core stays open, registry requires open source           |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The terminal is the oldest developer tool that still works. It doesn't need to b
 - AI features are opt-in, BYOK, and work with local models.
 - Open protocols — Kitty graphics, standard escape sequences, WASM plugins.
 - Platform-native, never Electron — AppKit on macOS, GTK on Linux, WinUI on Windows. macOS and Linux ship first; Windows follows.
-- Built-in multiplexer — you won't need tmux or Zellij, but they coexist cleanly if you do.
+- Built-in multiplexer — you won't need tmux, Zellij, or screen, but they coexist cleanly if you do.
 - Memory-conscious — tiered scroll buffer, per-pane budgets, no pre-allocation.
 - MPL 2.0 licensed — core stays open source, plugins can be any license.
 

--- a/docs/adrs/0010-layout-tree-model.md
+++ b/docs/adrs/0010-layout-tree-model.md
@@ -1,7 +1,7 @@
 ---
 adr: '0010'
 title: Layout Tree Model
-status: proposed
+status: accepted
 date: 2026-04-02
 tags: [core]
 ---

--- a/docs/adrs/0011-keybind-dispatch.md
+++ b/docs/adrs/0011-keybind-dispatch.md
@@ -1,7 +1,7 @@
 ---
 adr: '0011'
 title: Keybind Dispatch Architecture
-status: proposed
+status: accepted
 date: 2026-04-02
 tags: [core]
 ---

--- a/docs/adrs/0012-copy-mode-scrollback-access.md
+++ b/docs/adrs/0012-copy-mode-scrollback-access.md
@@ -1,7 +1,7 @@
 ---
 adr: '0012'
 title: Copy Mode Scrollback Access
-status: proposed
+status: accepted
 date: 2026-04-02
 tags: [core]
 ---

--- a/docs/adrs/0016-tmux-coexistence.md
+++ b/docs/adrs/0016-tmux-coexistence.md
@@ -1,7 +1,7 @@
 ---
 adr: '0016'
 title: tmux Coexistence Stance
-status: proposed
+status: accepted
 date: 2026-06-22
 tags: [core, multiplexer]
 ---
@@ -41,19 +41,16 @@ Cons: directly contradicts "replaces, not complements"; large, ongoing maintenan
 
 ## Decision
 
-**Proposed: Option B — graceful coexistence without integration.**
+**Option B — graceful coexistence without integration.**
 
 The stance is "you won't need tmux, but if you run it, it works correctly." We commit to the correctness bar — keyboard protocol passthrough, mouse/scrollback behavior, and (in the default configuration) never leaking tmux's alternate-screen history into native scrollback/search (consistent with [ADR-0006](0006-scroll-buffer-architecture.md)) — and explicitly do not build tmux control-mode integration, which would be complementing rather than replacing. This avoids kitty's reputational failure mode while keeping the principle intact.
-
-Status is `proposed` pending acceptance.
 
 ## Consequences
 
 - Testing: add a tmux-inside-OakTerm compatibility check (keyboard protocol passthrough, alt-screen scrollback isolation, mouse).
 - Alt-screen scrollback isolation follows from [ADR-0006](0006-scroll-buffer-architecture.md) under the default `save_alternate_scrollback = false` (tmux is an alt-screen app); this ADR makes "don't leak tmux history into native search/scrollbar" an explicit, tested guarantee **in the default configuration**. If a user opts into `save_alternate_scrollback = true` they have chosen to capture alt-screen content (tmux included); whether to add a tmux-specific capture exclusion is an open question.
 - No tmux control-mode work is scoped, now or later, unless this ADR is superseded.
-- If accepted, add a short "tmux coexistence" note to [03-multiplexer.md](../ideas/03-multiplexer.md) and reconcile the README "Replaces tmux, not complements it" line with the "works correctly if you use it" qualification.
-- Candidate for `/grill-me` stress-testing before acceptance.
+- [03-multiplexer.md](../ideas/03-multiplexer.md) and the README now frame the multiplexer as "you won't need tmux/Zellij/screen — but they coexist cleanly if you do," replacing the earlier "replaces tmux, not complements it" wording.
 
 ## References
 

--- a/docs/adrs/0017-rust-implementation-language.md
+++ b/docs/adrs/0017-rust-implementation-language.md
@@ -1,0 +1,84 @@
+---
+adr: '0017'
+title: Rust as the Implementation Language
+status: accepted
+date: 2026-06-30
+tags: [core, renderer, security]
+---
+
+# 0017. Rust as the Implementation Language
+
+## Context
+
+The foundational stack — Rust for the core, [wgpu](0018-gpu-rendering-wgpu.md) for rendering, [Wasmtime](0019-wasm-plugin-runtime-wasmtime.md) for plugins, Lua for config — is stated as fact in `CLAUDE.md` and [01-architecture.md](../ideas/01-architecture.md) but was never recorded as a decision. The 2026-06-30 choices audit flagged the language, GPU abstraction, and plugin runtime as load-bearing decisions with no ADR behind them.
+
+The language choice underlies three core principles at once: performance is non-negotiable (sub-frame input latency), secure by default (the terminal parses hostile untrusted byte streams — escape-sequence injection is a named threat), and accessible from day one. It is the one decision the rest of the stack is built on top of, so it earns its own record even though the project is already implemented in Rust.
+
+## Options
+
+### Option A: Rust
+
+Systems language with compile-time memory safety and no garbage collector.
+
+**Pros:**
+
+- Memory safety without a GC. GC pauses are incompatible with sub-frame latency; here safety is also a _security control_ — a terminal parses adversarial escape sequences, and memory-safety closes the injection-to-corruption path by construction.
+- The exact ecosystem this project needs is Rust-native: wgpu, Wasmtime, winit, swash/cosmic-text shaping, and AccessKit. AccessKit is the only portable accessibility library of its kind and it is Rust-first — day-one accessibility is far cheaper here than through an FFI boundary.
+- `Send`/`Sync` make the daemon/client split ([ADR-0007](0007-daemon-architecture.md)) tractable without data races.
+
+**Cons:**
+
+- Steeper contributor on-ramp than a managed language.
+- Compile times.
+
+### Option B: C++
+
+Native performance parity with Rust.
+
+**Pros:**
+
+- Peak performance; mature GPU tooling.
+
+**Cons:**
+
+- Memory-unsafe against exactly the hostile input a terminal handles — the injection threat becomes a memory-corruption threat.
+- Weaker, fragmented package story; no AccessKit equivalent; concurrency safety is manual.
+
+### Option C: Zig
+
+Modern systems language, strong C interop.
+
+**Pros:**
+
+- Simple, fast, excellent C interop (Ghostty is written in Zig).
+
+**Cons:**
+
+- Pre-1.0, moving target; no borrow-checker (manual memory safety against hostile input); no AccessKit-equivalent, no Rust-grade wgpu/Wasmtime equivalents — we would build the ecosystem ourselves.
+
+### Option D: A managed language (Go, etc.)
+
+Garbage-collected, fast to write.
+
+**Cons:**
+
+- GC pauses violate the latency principle; weaker native/GPU interop; not suited to a render loop with a hard frame budget.
+
+## Decision
+
+**Option A — Rust.**
+
+Rust is the only option that delivers native performance _and_ memory safety against hostile input _and_ a mature, Rust-native ecosystem for every seam this project depends on (GPU, WASM, shaping, accessibility). Memory safety here is a security control, not just an ergonomic benefit — it directly serves the "secure by default" principle against escape-sequence injection.
+
+## Consequences
+
+- The remainder of the stack ([wgpu](0018-gpu-rendering-wgpu.md), [Wasmtime](0019-wasm-plugin-runtime-wasmtime.md), winit, AccessKit, swash) follows from choosing Rust.
+- `unsafe` is confined and justified per use; the memory-management design deliberately avoids `unsafe mmap` ([ADR-0006](0006-scroll-buffer-architecture.md)).
+- Contributor onboarding assumes Rust fluency; the on-ramp cost is accepted as the price of the safety and ecosystem gains.
+
+## References
+
+- [01-architecture.md](../ideas/01-architecture.md)
+- [13-abstraction.md](../ideas/13-abstraction.md)
+- [21-security.md](../ideas/21-security.md)
+- [ADR-0007: Daemon Architecture](0007-daemon-architecture.md)

--- a/docs/adrs/0018-gpu-rendering-wgpu.md
+++ b/docs/adrs/0018-gpu-rendering-wgpu.md
@@ -1,0 +1,80 @@
+---
+adr: '0018'
+title: GPU Rendering via wgpu
+status: accepted
+date: 2026-06-30
+tags: [renderer, core, abstraction]
+---
+
+# 0018. GPU Rendering via wgpu
+
+## Context
+
+[02-renderer.md](../ideas/02-renderer.md) and [13-abstraction.md](../ideas/13-abstraction.md) specify GPU rendering behind a trait seam, and `CLAUDE.md` names wgpu as the backend, but the choice of wgpu over raw native graphics APIs was never recorded. [ADR-0002](0002-performance-philosophy.md) explicitly flagged the open risk: "wgpu adds an abstraction layer whose overhead for terminal rendering has not been benchmarked," and deferred resolution to Phase 0 prototyping. This ADR records wgpu as the rendering abstraction and names the competitive-parity benchmark as its validation gate.
+
+The tension is direct: the fastest terminals (Ghostty ~2ms on direct Metal, Alacritty on raw OpenGL) talk to the GPU natively, and performance is non-negotiable. Any abstraction layer must justify its overhead.
+
+## Options
+
+### Option A: wgpu behind a GPU trait seam
+
+Portable Rust-native GPU abstraction (WebGPU/WGSL) targeting Metal, Vulkan, DX12, and GL.
+
+**Pros:**
+
+- One WGSL shader path and one renderer across macOS/Linux/Windows, instead of maintaining Metal + Vulkan + DX12 backends separately.
+- Rust-native and production-proven on text-heavy GPU workloads (Zed, Bevy, Firefox use it).
+- The abstraction principle already mandates a swappable GPU seam; wgpu _is_ that seam, and if its overhead proves unacceptable the seam lets us drop to raw Metal for a platform without rewriting the terminal.
+
+**Cons:**
+
+- An abstraction layer over the native driver, with overhead that must be measured against direct-Metal competitors.
+
+### Option B: Raw native APIs per platform
+
+Metal on macOS, Vulkan/DX on others — the Ghostty approach.
+
+**Pros:**
+
+- Peak performance; no abstraction overhead; direct control.
+
+**Cons:**
+
+- Three separate GPU backends and shader languages to build and maintain — the largest ongoing cost in the renderer, for a solo/small effort.
+- Contradicts "abstracted at every seam."
+
+### Option C: A 2D graphics library (Skia, etc.)
+
+Render text and cells through a higher-level 2D API.
+
+**Cons:**
+
+- Large C++ dependency, weaker Rust integration, and less control over the glyph-atlas/compositing hot path than a shader we own.
+
+### Option D: OpenGL only
+
+Single legacy API (Alacritty's approach via glutin).
+
+**Cons:**
+
+- Deprecated on macOS; no modern-API access (Metal/Vulkan); a dead end for the compositing and image-protocol work ([ADR-0004](0004-kitty-graphics-in-core.md)) the renderer must do.
+
+## Decision
+
+**Option A — wgpu, behind a GPU trait seam, with a competitive-parity benchmark as the acceptance gate.**
+
+wgpu collapses three native backends into one WGSL codebase while the abstraction seam preserves the escape hatch to raw Metal if overhead demands it. The wgpu-overhead question from [ADR-0002](0002-performance-philosophy.md) is answered empirically: OakTerm's frame time and end-to-end input latency are benchmarked against Alacritty and Ghostty on the same hardware, and wgpu must reach competitive parity. If it cannot, the seam contains the blast radius of switching a platform to native.
+
+## Consequences
+
+- A criterion benchmark comparing OakTerm frame/latency against Alacritty and Ghostty is the validation gate for this decision (tracked as a renderer spike; per [ADR-0002](0002-performance-philosophy.md)'s benchmark discipline).
+- Shaders are authored in WGSL; the glyph atlas and cell compositing target the wgpu pipeline.
+- The GPU backend stays behind a trait ([13-abstraction.md](../ideas/13-abstraction.md)); a raw-Metal fallback is _reserved_ but not built unless benchmarks force it.
+- The image-compositing API ([ADR-0004](0004-kitty-graphics-in-core.md)) is expressed in terms of the wgpu pipeline.
+
+## References
+
+- [02-renderer.md](../ideas/02-renderer.md)
+- [13-abstraction.md](../ideas/13-abstraction.md)
+- [ADR-0002: Performance Philosophy](0002-performance-philosophy.md)
+- [ADR-0004: Kitty Graphics in Core](0004-kitty-graphics-in-core.md)

--- a/docs/adrs/0019-wasm-plugin-runtime-wasmtime.md
+++ b/docs/adrs/0019-wasm-plugin-runtime-wasmtime.md
@@ -1,0 +1,89 @@
+---
+adr: '0019'
+title: WASM Plugin Runtime via Wasmtime
+status: accepted
+date: 2026-06-30
+tags: [plugins, core, security, abstraction]
+---
+
+# 0019. WASM Plugin Runtime via Wasmtime
+
+## Context
+
+[06-plugins.md](../ideas/06-plugins.md) and the "plugin is the product" principle require a sandboxed WASM runtime for third-party plugins. `CLAUDE.md` names Wasmtime, but the choice over other WASM runtimes was never recorded. The runtime must satisfy three constraints that competing engines meet unevenly:
+
+1. **Never block the render loop** — a runaway or malicious plugin must be preemptible by the host.
+2. **Capability-based security** — plugins get only the capabilities they are granted (secure by default).
+3. **A typed API contract** — the plugin API is defined in WIT / the Component Model, so the runtime's component support must be first-class, not bolted on.
+
+## Options
+
+### Option A: Wasmtime
+
+Bytecode Alliance's runtime; Cranelift JIT; reference implementation of the Component Model and WASI Preview 2.
+
+**Pros:**
+
+- Reference implementation of the Component Model / WIT — the project's chosen plugin-API contract is native, not emulated.
+- **Epoch-based interruption** and fuel metering let the host preempt a plugin that overruns its time budget, which is exactly the "plugins never block the render loop" guarantee.
+- WASI Preview 2 capability model maps onto capability-based plugin permissions.
+- Production-hardened (Fastly, Fermyon, Shopify); actively maintained; Rust-native.
+
+**Cons:**
+
+- Cranelift JIT is a larger dependency than an interpreter-only runtime.
+
+### Option B: Wasmer
+
+Mature alternative runtime with multiple backends.
+
+**Pros:**
+
+- Fast; multiple compiler backends; broad platform support.
+
+**Cons:**
+
+- Weaker/later Component Model story than Wasmtime; past licensing/governance friction makes it a less stable long-term foundation than a Bytecode Alliance project.
+
+### Option C: WAMR (WebAssembly Micro Runtime)
+
+Tiny interpreter/AOT runtime.
+
+**Pros:**
+
+- Minimal footprint; good for constrained embeds.
+
+**Cons:**
+
+- Interpreter performance and less mature Component Model tooling; the footprint win doesn't matter for a desktop terminal, while the component-model and preemption gaps do.
+
+### Option D: Extism
+
+Higher-level plugin framework built on top of a WASM runtime.
+
+**Pros:**
+
+- Convenient plugin ergonomics out of the box.
+
+**Cons:**
+
+- Wraps a runtime we would rather control directly, precisely for the epoch-interruption / render-loop-preemption guarantee; the extra layer works against "abstracted at every seam" by hiding the engine we need to configure.
+
+## Decision
+
+**Option A — Wasmtime.**
+
+Wasmtime is the only option that natively provides all three requirements: first-class Component Model / WIT (the plugin-API contract), epoch-based preemption (the render-loop guarantee), and a WASI capability model (capability-based permissions) — under stable Bytecode Alliance governance. The JIT dependency size is an acceptable cost for a desktop application.
+
+## Consequences
+
+- The plugin API is defined in WIT and hosted through the Component Model.
+- Epoch interruption is configured so the host can preempt plugins that exceed their execution budget; plugins run off the render-critical path.
+- Plugin capabilities are wired through WASI Preview 2 grants — deny by default, relaxable per manifest.
+- The runtime sits behind an abstraction seam ([13-abstraction.md](../ideas/13-abstraction.md)) so it remains swappable if a stronger WASM runtime emerges.
+
+## References
+
+- [06-plugins.md](../ideas/06-plugins.md)
+- [13-abstraction.md](../ideas/13-abstraction.md)
+- [21-security.md](../ideas/21-security.md)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -27,21 +27,24 @@ Copy [0000-template.md](0000-template.md) and renumber.
 
 ## Index
 
-| ADR                                         | Title                          | Status   | Tags                                  |
-| ------------------------------------------- | ------------------------------ | -------- | ------------------------------------- |
-| [0001](0001-accessibility-in-phase-zero.md) | Accessibility in Phase 0       | accepted | a11y, renderer                        |
-| [0002](0002-performance-philosophy.md)      | Performance Philosophy         | accepted | renderer, core                        |
-| [0003](0003-update-check-policy.md)         | Update Check Policy            | accepted | security, core                        |
-| [0004](0004-kitty-graphics-in-core.md)      | Kitty Graphics in Core         | accepted | renderer, plugins                     |
-| [0005](0005-lua-sandboxed-config.md)        | Lua 5.4 Sandboxed Config       | accepted | config, core                          |
-| [0006](0006-scroll-buffer-architecture.md)  | Scroll Buffer Architecture     | accepted | renderer, core                        |
-| [0007](0007-daemon-architecture.md)         | Daemon Architecture            | accepted | core, renderer                        |
-| [0008](0008-shell-integration-timing.md)    | Shell Integration Timing       | accepted | core                                  |
-| [0009](0009-bidi-ligature-preparedness.md)  | BiDi and Ligature Preparedness | accepted | renderer, core                        |
-| [0010](0010-layout-tree-model.md)           | Layout Tree Model              | proposed | core                                  |
-| [0011](0011-keybind-dispatch.md)            | Keybind Dispatch Architecture  | proposed | core                                  |
-| [0012](0012-copy-mode-scrollback-access.md) | Copy Mode Scrollback Access    | proposed | core                                  |
-| [0013](0013-fig-autocomplete-schema.md)     | Fig Autocomplete Schema        | proposed | context-engine, completion, plugins   |
-| [0014](0014-input-classifier.md)            | Input Mode Classification      | proposed | context-engine, ai, shell-integration |
-| [0015](0015-command-blocks.md)              | Command Blocks UX              | proposed | renderer, shell-integration, plugins  |
-| [0016](0016-tmux-coexistence.md)            | tmux Coexistence Stance        | proposed | core, multiplexer                     |
+| ADR                                          | Title                          | Status   | Tags                                  |
+| -------------------------------------------- | ------------------------------ | -------- | ------------------------------------- |
+| [0001](0001-accessibility-in-phase-zero.md)  | Accessibility in Phase 0       | accepted | a11y, renderer                        |
+| [0002](0002-performance-philosophy.md)       | Performance Philosophy         | accepted | renderer, core                        |
+| [0003](0003-update-check-policy.md)          | Update Check Policy            | accepted | security, core                        |
+| [0004](0004-kitty-graphics-in-core.md)       | Kitty Graphics in Core         | accepted | renderer, plugins                     |
+| [0005](0005-lua-sandboxed-config.md)         | Lua 5.4 Sandboxed Config       | accepted | config, core                          |
+| [0006](0006-scroll-buffer-architecture.md)   | Scroll Buffer Architecture     | accepted | renderer, core                        |
+| [0007](0007-daemon-architecture.md)          | Daemon Architecture            | accepted | core, renderer                        |
+| [0008](0008-shell-integration-timing.md)     | Shell Integration Timing       | accepted | core                                  |
+| [0009](0009-bidi-ligature-preparedness.md)   | BiDi and Ligature Preparedness | accepted | renderer, core                        |
+| [0010](0010-layout-tree-model.md)            | Layout Tree Model              | accepted | core                                  |
+| [0011](0011-keybind-dispatch.md)             | Keybind Dispatch Architecture  | accepted | core                                  |
+| [0012](0012-copy-mode-scrollback-access.md)  | Copy Mode Scrollback Access    | accepted | core                                  |
+| [0013](0013-fig-autocomplete-schema.md)      | Fig Autocomplete Schema        | proposed | context-engine, completion, plugins   |
+| [0014](0014-input-classifier.md)             | Input Mode Classification      | proposed | context-engine, ai, shell-integration |
+| [0015](0015-command-blocks.md)               | Command Blocks UX              | proposed | renderer, shell-integration, plugins  |
+| [0016](0016-tmux-coexistence.md)             | tmux Coexistence Stance        | accepted | core, multiplexer                     |
+| [0017](0017-rust-implementation-language.md) | Rust Implementation Language   | accepted | core, renderer, security              |
+| [0018](0018-gpu-rendering-wgpu.md)           | GPU Rendering via wgpu         | accepted | renderer, core, abstraction           |
+| [0019](0019-wasm-plugin-runtime-wasmtime.md) | WASM Plugin Runtime (Wasmtime) | accepted | plugins, core, security, abstraction  |

--- a/docs/ideas/01-architecture.md
+++ b/docs/ideas/01-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: 'Architecture'
-status: reviewing
+status: decided
 category: core
 description: 'Layer stack, Rust, server/client model'
 tags: ['rust', 'wgpu', 'server-client', 'layer-stack']

--- a/docs/ideas/02-renderer.md
+++ b/docs/ideas/02-renderer.md
@@ -1,6 +1,6 @@
 ---
 title: 'Renderer'
-status: reviewing
+status: decided
 category: core
 description: 'GPU (wgpu), fonts, fallbacks, ligatures, opacity, color, images'
 tags: ['gpu', 'wgpu', 'fonts', 'ligatures', 'images', 'opacity', 'color']

--- a/docs/ideas/03-multiplexer.md
+++ b/docs/ideas/03-multiplexer.md
@@ -20,7 +20,7 @@ tags:
 
 # Multiplexer
 
-Built-in. Replaces tmux, Zellij, and screen.
+Built-in. You won't need tmux, Zellij, or screen — but if you already use them (remote SSH sessions, muscle memory), they coexist cleanly ([ADR-0016](../adrs/0016-tmux-coexistence.md)).
 
 ## Hierarchy
 
@@ -354,5 +354,5 @@ copy_mode_keybinds = "vim"     -- default
 - [Architecture](01-architecture.md) — where the multiplexer sits in the layer stack
 - [Sidebar](04-sidebar.md) — pane navigation and process dashboard
 - [Memory Management](15-memory-management.md) — scroll buffer strategy (ring + disk archive)
-- [Session persistence is part of the multiplexer, serialization format TBD]
+- [Spec 0010: Session Persistence](../specs/0010-session-persistence.md) — workspace/tab/pane serialization and restore
 - [Platform Support](20-platform-support.md) — Wayland vs X11, clipboard handling per platform

--- a/docs/ideas/06-plugins.md
+++ b/docs/ideas/06-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: 'Plugin System'
-status: reviewing
+status: decided
 category: cross-cutting
 description: 'WASM runtime, API primitives, capabilities, registry, manager'
 tags: ['wasm', 'wasmtime', 'api', 'capabilities', 'registry', 'lua']

--- a/docs/ideas/09-config.md
+++ b/docs/ideas/09-config.md
@@ -1,6 +1,6 @@
 ---
 title: 'Configuration'
-status: reviewing
+status: decided
 category: cross-cutting
 description: 'First launch setup, settings palette, Lua config, dark/light themes'
 tags: ['config', 'lua', 'settings-palette', 'first-launch', 'dark-mode']

--- a/docs/ideas/10-pain-points.md
+++ b/docs/ideas/10-pain-points.md
@@ -15,7 +15,7 @@ Real complaints from GitHub issues, Hacker News, and developer forums that direc
 Agent workloads emit huge, heavy-Unicode output streams that push scrollback memory into double-digit gigabytes across every major terminal.
 
 **Source:** Ghostty #10289 (71 GB with Claude Code; fixed in Ghostty 1.3, Mar 2026), Claude Code #11315 (129 GB), #4953 (120 GB), #32752 (18 GB/hour growth). iTerm2 routinely 3 GB+. WezTerm pre-allocates scrollback.
-**Solution:** Bound memory by design rather than retrofit limits after a leak. A tiered scroll buffer caps in-memory scrollback at a byte ceiling and overflows to a compressed disk archive, so RSS grows to the configured limit and stabilizes there. Per-pane budgets and memory attribution in `:debug memory` and the sidebar separate terminal memory from child-process memory, with alerts when a child grows abnormally. See `ideas/15-memory-management.md`.
+**Solution:** Bound memory by design rather than retrofit limits after a leak. A tiered scroll buffer caps in-memory scrollback at a byte ceiling and overflows to a compressed disk archive, so RSS grows to the configured limit and stabilizes there. Per-pane budgets and memory attribution in `:debug memory` and the sidebar separate terminal memory from child-process memory, with alerts when a child grows abnormally. See [15-memory-management.md](15-memory-management.md).
 
 ## Clipboard over SSH + multiplexer is universally broken
 

--- a/docs/ideas/10-pain-points.md
+++ b/docs/ideas/10-pain-points.md
@@ -12,8 +12,10 @@ Real complaints from GitHub issues, Hacker News, and developer forums that direc
 
 ## Terminal memory explodes with AI agents
 
-**Source:** Ghostty #10289 (71 GB with Claude Code), Claude Code #11315 (129 GB), #4953 (120 GB), #32752 (18 GB/hour growth). iTerm2 routinely 3 GB+. WezTerm pre-allocates scrollback.
-**Solution:** Tiered scroll buffer — ring buffer in memory (hard ceiling), overflow to compressed disk archive. Per-pane memory budgets. Memory attribution in `:debug memory` and sidebar clearly shows terminal memory vs child process memory. Alerts when a child process grows abnormally. See `ideas/15-memory-management.md`.
+Agent workloads emit huge, heavy-Unicode output streams that push scrollback memory into double-digit gigabytes across every major terminal.
+
+**Source:** Ghostty #10289 (71 GB with Claude Code; fixed in Ghostty 1.3, Mar 2026), Claude Code #11315 (129 GB), #4953 (120 GB), #32752 (18 GB/hour growth). iTerm2 routinely 3 GB+. WezTerm pre-allocates scrollback.
+**Solution:** Bound memory by design rather than retrofit limits after a leak. A tiered scroll buffer caps in-memory scrollback at a byte ceiling and overflows to a compressed disk archive, so RSS grows to the configured limit and stabilizes there. Per-pane budgets and memory attribution in `:debug memory` and the sidebar separate terminal memory from child-process memory, with alerts when a child grows abnormally. See `ideas/15-memory-management.md`.
 
 ## Clipboard over SSH + multiplexer is universally broken
 

--- a/docs/ideas/12-performance.md
+++ b/docs/ideas/12-performance.md
@@ -1,6 +1,6 @@
 ---
 title: 'Performance'
-status: reviewing
+status: decided
 category: cross-cutting
 description: 'Targets, budgets, CI benchmarks'
 tags: ['latency', 'memory', 'benchmarks', 'ci']

--- a/docs/ideas/15-memory-management.md
+++ b/docs/ideas/15-memory-management.md
@@ -1,6 +1,6 @@
 ---
 title: 'Memory Management'
-status: reviewing
+status: decided
 category: cross-cutting
 description: 'Tiered scroll buffer, per-pane budgets, memory attribution'
 tags: ['memory', 'scroll-buffer', 'ring-buffer', 'disk-archive', 'agents']

--- a/docs/ideas/16-wishlist-features.md
+++ b/docs/ideas/16-wishlist-features.md
@@ -72,12 +72,6 @@ Native OS notification when a long-running command finishes in a background tab/
 
 **Status:** Specced in [Shell Integration](18-shell-integration.md). Uses OSC 133;D exit code + configurable duration threshold.
 
-### Process Completion Notifications
-
-Native OS notification when a long-running command finishes in a background tab/pane. Ghostty 1.3 added this.
-
-**Fits:** Shell integration + notification system
-
 ## Could Have (good ideas, lower priority)
 
 ### Semantic Zone Selection

--- a/docs/ideas/17-accessibility.md
+++ b/docs/ideas/17-accessibility.md
@@ -1,6 +1,6 @@
 ---
 title: 'Accessibility'
-status: reviewing
+status: decided
 category: cross-cutting
 description: 'AccessKit, screen reader, color blindness, extensible a11y API'
 tags: ['a11y', 'accesskit', 'screen-reader', 'voiceover', 'color-blindness']

--- a/docs/ideas/18-shell-integration.md
+++ b/docs/ideas/18-shell-integration.md
@@ -1,6 +1,6 @@
 ---
 title: 'Shell Integration'
-status: reviewing
+status: decided
 category: core
 description: 'Prompt markers, semantic zones, scroll-to-prompt, notifications'
 tags: ['shell', 'osc-133', 'prompt-markers', 'scroll-to-prompt']

--- a/docs/ideas/24-updates.md
+++ b/docs/ideas/24-updates.md
@@ -1,6 +1,6 @@
 ---
 title: 'Updates'
-status: reviewing
+status: decided
 category: cross-cutting
 description: 'Every update path works, staged updates, rollback'
 tags: ['updates', 'rollback', 'release-channels', 'package-manager']

--- a/docs/specs/0001-daemon-wire-protocol.md
+++ b/docs/specs/0001-daemon-wire-protocol.md
@@ -92,6 +92,15 @@ server_version           UTF-8 bytes       OakTerm version string (e.g., "0.1.0"
 - If `status != 0`, the server closes the connection after sending ServerHello.
 - After successful handshake, both sides may send frames freely according to the message catalog.
 
+**Versioning governance:**
+
+The negotiation rules above describe how a mismatch is _handled_; these rules define what constitutes each kind of change, so that "major = breaking" is unambiguous:
+
+- **Additive (minor bump):** a new `msg_type`, or a new field appended to the trailing end of an existing payload such that older peers can ignore the extra bytes. A minor bump must not change the meaning or wire layout of any existing field.
+- **Breaking (major bump):** removing or repurposing a `msg_type`; changing the type, order, width, or semantics of any existing field; or altering the framing or handshake layout.
+- **Retired `msg_type` numbers are never reused.** A removed message type's number is burned, not recycled, so a stale peer can never misinterpret a new message as an old one.
+- Forward compatibility within a major version rests on the unknown-`msg_type` rule (ignore the frame — see [Error Cases](#error-cases)); additive changes are only safe because of it.
+
 ### Message Catalog
 
 #### Infrastructure Messages (0x00-0x09)

--- a/docs/specs/0001-daemon-wire-protocol.md
+++ b/docs/specs/0001-daemon-wire-protocol.md
@@ -96,7 +96,7 @@ server_version           UTF-8 bytes       OakTerm version string (e.g., "0.1.0"
 
 The negotiation rules above describe how a mismatch is _handled_; these rules define what constitutes each kind of change, so that "major = breaking" is unambiguous:
 
-- **Additive (minor bump):** a new `msg_type`, or a new field appended to the trailing end of an existing payload such that older peers can ignore the extra bytes. A minor bump must not change the meaning or wire layout of any existing field.
+- **Additive (minor bump):** a new `msg_type`. Appending a field to an existing message's payload counts as additive only when the chosen serialization tolerates unknown trailing data (protobuf does; a fixed hand-rolled binary layout does not) — otherwise a field addition is breaking. A minor bump must never change the meaning, type, order, or width of any existing field.
 - **Breaking (major bump):** removing or repurposing a `msg_type`; changing the type, order, width, or semantics of any existing field; or altering the framing or handshake layout.
 - **Retired `msg_type` numbers are never reused.** A removed message type's number is burned, not recycled, so a stale peer can never misinterpret a new message as an old one.
 - Forward compatibility within a major version rests on the unknown-`msg_type` rule (ignore the frame — see [Error Cases](#error-cases)); additive changes are only safe because of it.


### PR DESCRIPTION
Closes out the 2026-06 strategic choices audit. Documentation only — no code changes.

## What & why

The audit re-validated OakTerm's vision against the 2026 terminal landscape (the vision holds) and surfaced execution-level gaps in the docs. This PR resolves them.

### Positioning (commit 1)
- **Memory story re-grounded** (`10-pain-points.md`): Ghostty's specific scrollback leak was fixed in 1.3 (Mar 2026), so the narrative shifts from "we prevent Ghostty's leak" to the recurring *class* of problem, bounded by design (byte-capped ring + disk overflow; RSS grows to the limit and stabilizes).
- **tmux coexistence stance** (`README.md`, `03-multiplexer.md`): "you won't need tmux/Zellij/screen, but they coexist cleanly if you do," replacing "replaces tmux, not complements it."
- Platform framing (macOS + Linux first, Windows follows) and Phase-1 status aligned with reality.

### Decisions layer (commit 2)
- **New foundational ADRs** — the Rust / wgpu / Wasmtime choices were stated as fact but never recorded. ADR-0017 (Rust), ADR-0018 (wgpu), ADR-0019 (Wasmtime) capture alternatives and project-specific rationale (memory-safety as a security control; the wgpu competitive-parity gate; Wasmtime epoch preemption + Component Model).
- **ADR-0016 (tmux coexistence) accepted** now that the stance is reconciled in the docs.
- **ADR-0010/0011/0012 flipped to accepted** to match their downstream specs, which are already accepted or complete (stale bookkeeping).
- **Spec-0001** gains a versioning-governance note (breaking vs additive; never reuse a retired `msg_type`).

### Idea-doc bookkeeping (commit 3)
- Nine idea docs moved `reviewing` → `decided` (their ADRs/specs are settled).
- Removed a duplicated section from the wishlist.

## Follow-ups (tracked, not in this PR)
- **TREK-166** — wgpu frame/latency parity benchmark vs Alacritty & Ghostty (validation gate for ADR-0018), runs during Phase-1 renderer validation.
- ADR-0013/0014/0015 stay `proposed` — no spec formalizes them yet (Phase 2/3).

## Checks
- `mise run fmt` + `mise run lint` clean (0 errors)
- Reviewed across three Codex + cleanup (de-slopify) rounds — no findings

https://claude.ai/code/session_013Lw1gM3artqQ2MStk5UhwA