### PR TITLE
docs(docs): absorb ADR-0022-0024 and record as-built specs

### DIFF
--- a/docs/adrs/0011-keybind-dispatch.md
+++ b/docs/adrs/0011-keybind-dispatch.md
@@ -103,7 +103,7 @@ Input flows through these layers in order:
 | `oak_mod + P`           | Command palette                                                                  |
 | `oak_mod + R`           | Enter resize mode                                                                |
 
-Tab cycling deliberately breaks the `oak_mod` pattern: on Linux `oak_mod + Shift` folds into `oak_mod` (a chord cannot repeat a modifier), which would collide with `oak_mod + [` copy mode, so each platform gets its native tab-cycling convention instead. Until the configurable `oak_mod` machinery lands, default keybinds ship pre-expanded to the platform's `oak_mod` value.
+Tab cycling deliberately breaks the `oak_mod` pattern: on Linux `oak_mod + Shift` folds into `oak_mod` (a chord cannot repeat a modifier), which would collide with `oak_mod + [` copy mode, so each platform gets its native tab-cycling convention instead. Default keybinds are expanded against the configured `oak_mod` value at config-extraction time (`KeybindRegistry::with_defaults_for`; see As Built).
 
 ### Key tables
 
@@ -136,7 +136,7 @@ oakterm.keybind("leader+\"", oakterm.action.split_pane({ direction = "down" }))
 oakterm.config.copy_mode_keybinds = "vim"  -- or "emacs" or "basic"
 ```
 
-`oak_mod` in a keybind string is expanded at registration time to the configured modifier. This means changing `oak_mod` after keybinds are registered does not retroactively update them — `oak_mod` must be set before keybinds.
+`oak_mod` in a keybind string is expanded at config-extraction time to the configured modifier — see As Built.
 
 ### Performable actions
 
@@ -149,6 +149,15 @@ Borrowed from Ghostty: some actions are context-dependent. `oakterm.action.copy(
 - The wire protocol does not need changes for keybind dispatch; keybinds are resolved in the GUI process before input is forwarded to the daemon.
 - Copy mode key table and resize mode key table will be specified in their respective specs (Spec-0008 Copy Mode).
 - The status bar spec must include mode indicator display.
+
+## As Built
+
+Four places where the shipped implementation (`crates/oakterm-config/src/keybind.rs`, `proxy.rs`) corrected or refined this decision:
+
+- **`oak_mod` is order-independent, not "must be set before keybinds."** This ADR specified registration-time expansion, which implied `oak_mod` had to be set before the keybinds that use it. The shipped runtime instead resolves `oak_mod` at config-extraction time against the config's final value, so file order doesn't matter — this ADR's original constraint doesn't hold. Full validation and token contract: [Spec-0005](../specs/0005-lua-config-runtime.md).
+- **Overlap between `oak_mod` and an explicit modifier folds instead of erroring.** See Spec-0005 for the fold-vs-error contract; explicit duplicate modifiers (not involving `oak_mod`) still error regardless.
+- **Leader dispatch consumes silently instead of releasing to the PTY.** Spec-0005 covers the leader table's separate-namespace shape and the unset-`leader`-warns behavior. What it doesn't cover, because it's dispatch runtime rather than config extraction: a non-performable leader action is consumed silently — the leader chord already swallowed the keypress, so there's nothing to release — while a non-performable default-layer binding instead releases the key to the PTY, per the Performable Actions section above.
+- **Default keybinds register wired-only.** Only actions with a working handler register as defaults (Spec-0009's registration policy applies here too). The live wired set: split right (`oak_mod+\`) and split down (`oak_mod+-`); focus pane left/down/up/right (`oak_mod+h/j/k/l`, TREK-109); new tab (`oak_mod+t`); close pane (`oak_mod+w`); command palette (`oak_mod+p`); tab-cycling; prompt navigation (`oak_mod+shift+up`/`down`); and the four scroll defaults (`shift+pageup`/`pagedown`/`home`/`end`). Copy mode, resize mode, floating, and zoom stay unregistered until their actions land.
 
 ## References
 

--- a/docs/ideas/04-sidebar.md
+++ b/docs/ideas/04-sidebar.md
@@ -52,7 +52,7 @@ Not a file tree. Not a session list. It shows **things that are running** — gr
 
 **Agents** — autonomous processes that produce code and need review
 
-- Status: working / needs input / done / error
+- Status: five lifecycle states — `working` / `blocked` / `done` / `idle` / `unknown` — plus an outcome (`success` / `error` / `cancelled`) attached at completion ([ADR-0023](../adrs/0023-agent-state-vocabulary.md)). `done` moves to `idle` on daemon-global acknowledgment (any client viewing the pane clears it everywhere); the attention cycle drains `done+error`, then `blocked`, then `done+success`. `done+success` and `done+cancelled` age out via the recency window even if never acknowledged; `done+error` and `blocked` never age out.
 - Context window %, branch, files changed
 - Memory usage (child process RSS) with growth indicator
 
@@ -122,14 +122,14 @@ Folders are sidebar-side organization only — the daemon's `Workspace → Tab �
 
 Each category has its own notification logic:
 
-| Category | Notifies when                                 |
-| -------- | --------------------------------------------- |
-| Agent    | Needs approval, finished, errored             |
-| Service  | Crashes, port conflict, restart loop          |
-| Watcher  | Tests go red, type errors appear, build fails |
-| Shell    | Process exits (configurable)                  |
+| Category | Notifies when                                                  |
+| -------- | -------------------------------------------------------------- |
+| Agent    | Enters `blocked`, reaches `done+error`, reaches `done+success` |
+| Service  | Crashes, port conflict, restart loop                           |
+| Watcher  | Tests go red, type errors appear, build fails                  |
+| Shell    | Process exits (configurable)                                   |
 
-`Cmd+Shift+U` cycles through everything that needs attention.
+`Cmd+Shift+U` cycles through everything that needs attention, draining agent entries in ADR-0023's priority order: `done+error`, then `blocked`, then `done+success` ([ADR-0023](../adrs/0023-agent-state-vocabulary.md)).
 
 ## Interaction
 
@@ -151,6 +151,7 @@ A Docker/Podman plugin adds a CONTAINERS section to the sidebar. Auto-discovers 
 
 - [Plugin System](06-plugins.md) — sidebar data model (core) and sidebar-ui (plugin)
 - [Agent Management](07-agent-management.md) — AGENTS section
+- [ADR-0023](../adrs/0023-agent-state-vocabulary.md) — agent state vocabulary and attention-cycle ordering
 - [Memory Management](15-memory-management.md) — per-pane memory display
 - [Harpoon](27-harpoon.md) — pane bookmarks complement the sidebar
 - [Remote Access](29-remote-access.md) — remote panes appear in sidebar

--- a/docs/ideas/07-agent-management.md
+++ b/docs/ideas/07-agent-management.md
@@ -28,7 +28,9 @@ Agents never touch your working directory. Run 5 agents in parallel on the same 
 
 ## Status Tracking
 
-The plugin watches agent processes for state changes:
+State comes from a three-tier precedence, not from watching output alone ([ADR-0024](../adrs/0024-agent-state-sources.md)): the daemon's process detection owns pane liveness unconditionally — a vanished process is always `done`, never `working`, regardless of what any other source last claimed. Above that floor, an explicit agent-level report (ACP `session/update`, an agent hook, or `oakterm ctl self set-status`) is authoritative for semantic state and overrides pattern matching for the rest of the session; the screen heuristics below only run when no explicit agent-level source has spoken — shell-level OSC 133 marks alone do not suppress them. OSC 133 marks are authoritative for command lifecycle only and never claim agent semantic state. A subagent-stop event maps to the parent pane's `working`, never to `done`.
+
+The plugin's heuristic layer — the floor beneath explicit reports — watches agent process output for state changes:
 
 | Badge | Meaning                 |
 | ----- | ----------------------- |
@@ -36,6 +38,8 @@ The plugin watches agent processes for state changes:
 | ❓    | Needs approval or input |
 | ✓     | Finished                |
 | ✗     | Errored                 |
+
+These map onto [ADR-0023](../adrs/0023-agent-state-vocabulary.md)'s lifecycle states (`working`, `blocked`, `done`+outcome) — this table is the heuristic-detection badge set, not the full vocabulary. When no pattern matches, the pane reports `unknown` rather than guessing.
 
 Context window usage shown as a progress bar in the sidebar.
 
@@ -98,7 +102,7 @@ agent_providers = {
 }
 ```
 
-The plugin detects state from process output. Provider-specific detection patterns are configurable.
+Provider-specific heuristic patterns are configurable and used as the fallback tier when a provider offers no ACP session, hook, or self-report channel ([ADR-0024](../adrs/0024-agent-state-sources.md)).
 
 ## Workspace Setup Scripts (from Conductor)
 
@@ -134,4 +138,6 @@ Fork a workspace at its current state to try something risky. Git worktrees make
 - [Memory Management](15-memory-management.md) — child process memory attribution
 - [Shell Integration](18-shell-integration.md) — command completion notifications
 - [Agent Protocol](39-agent-protocol.md) — structured channel for ACP-aware agents (complements the lifecycle managed here)
+- [ADR-0023](../adrs/0023-agent-state-vocabulary.md) — the state vocabulary this plugin's badges map onto
+- [ADR-0024](../adrs/0024-agent-state-sources.md) — the three-tier precedence heuristic detection sits under
 - [Agent Tooling Landscape Audit](../reviews/2026-08-16-215731-agent-tooling-landscape-audit.md) — scrollback-breakage re-verification, 2026 agent-tooling prior art

--- a/docs/ideas/32-agent-control-api.md
+++ b/docs/ideas/32-agent-control-api.md
@@ -27,6 +27,8 @@ oakterm ctl <command> [args]
 
 The `ctl` subcommand connects to the running daemon via `$OAKTERM_SOCKET` (auto-set in every pane's environment). The daemon knows which pane the request came from.
 
+Three layers of the same control surface, each for a different caller: a `SKILL.md` (planned, TREK-278) will give agents workflow guidance without reading this doc; the `oakterm ctl` CLI below is what shell scripts and most agents call; long-lived programs can hit the raw daemon socket directly. This doc sketches the surface; the forthcoming Spec-0012 (Agent Control API, TREK-278) formalizes the wire contract, ID scheme, and precedence rules the daemon enforces.
+
 ### Pane Management
 
 ```bash
@@ -43,34 +45,49 @@ oakterm ctl pane list                             # all panes (JSON)
 oakterm ctl pane list --format table              # human-readable
 
 # Read output from another pane
-oakterm ctl pane output <pane-id>                 # last 100 lines
-oakterm ctl pane output <pane-id> --lines 500     # last 500 lines
-oakterm ctl pane output <pane-id> --follow        # stream new output
+oakterm ctl pane read <pane-id>                                  # last 100 lines, --source recent (default)
+oakterm ctl pane read <pane-id> --lines 500                      # last 500 lines
+oakterm ctl pane read <pane-id> --follow                         # stream new output
+oakterm ctl pane read <pane-id> --source visible                 # current viewport only
+oakterm ctl pane read <pane-id> --source recent-unwrapped        # scrollback with soft wraps joined back — the form `wait output` matches against
 
-# Send input to another pane
-oakterm ctl pane input <pane-id> "npm run build"
-oakterm ctl pane input <pane-id> --enter          # press enter
+# Send input to another pane — split by what a TTY actually accepts (herdr precedent)
+oakterm ctl pane send-text <pane-id> "npm run build"             # literal text, no Enter
+oakterm ctl pane send-keys <pane-id> Enter                       # keypresses: Enter, Esc, C-c, ...
+oakterm ctl pane send-input <pane-id> "npm run build" Enter      # atomic literal + keys, in order
+
+# Block until a condition is met, instead of polling
+oakterm ctl wait output <pane-id> --match "ready on port 3000" --timeout 30000
+oakterm ctl wait output <pane-id> --regex "port \d+" --timeout 30000
+oakterm ctl wait status <pane-id> --status done --timeout 60000
 
 # Focus
 oakterm ctl pane focus <pane-id>                  # switch view to a pane
 
 # Close
 oakterm ctl pane close <pane-id>
+
+# Return a hook-claimed pane to plain-shell state (agent exited or was released explicitly)
+oakterm ctl pane release <pane-id>                # scoped per ADR-0024 rule 5: only panes an agent claimed on top of a surviving shell; a pane whose child process *is* the agent exits via rule 1 instead
 ```
+
+Pane IDs have a **dual stable + compact form**, matching herdr's contract: responses always return the stable opaque ID (`OAKTERM_PANE_ID`-shaped, stable for the pane's lifetime); requests accept either the stable ID or the compact human-readable shorthand (e.g. `1-2`), which may renumber when peers close. Agents script against the stable form; humans type the compact one interactively.
 
 ### Self (current pane)
 
 ```bash
 # Set metadata on the calling pane
 oakterm ctl self set-title "Building auth module"
-oakterm ctl self set-status working               # working, needs-input, done, error
+oakterm ctl self set-status working               # working | blocked | done [--outcome success|error|cancelled]
 oakterm ctl self set-color "#a6e3a1"              # tab/sidebar accent color
 oakterm ctl self set-progress 65                  # progress bar (0-100)
-oakterm ctl self set-badge "3 files changed"
+oakterm ctl self set-badge "3 files changed"      # free-form detail string, doesn't affect cycling/filtering
 
 # Read own pane info
 oakterm ctl self info                             # JSON: pane-id, cwd, title, status
 ```
+
+`set-status` only accepts the three states a pane can self-report (ADR-0023): `working`, `blocked`, and `done` (paired with `--outcome success|error|cancelled`). `idle` and `unknown` are not self-reportable — `idle` is reached only by daemon-global acknowledgment of a `done` pane, and `unknown` is what the heuristic floor reports when nothing else has spoken.
 
 ### Notifications
 
@@ -119,11 +136,11 @@ Not every agent should be able to do everything. Permissions are **per-pane**, s
 ```lua
 -- When launching an agent
 agent_permissions = {
-  self = true,          -- can set own title, status, color (always allowed)
+  self = true,          -- can set own title, status, color, badge (always allowed)
   notify = true,        -- can send notifications (default: true)
   pane_create = true,   -- can open new panes (default: false)
   pane_read = false,    -- can read other panes' output (default: false)
-  pane_input = false,   -- can send input to other panes (default: false)
+  pane_input = false,   -- can send-text/send-keys/send-input to other panes (default: false)
   pane_close = false,   -- can close other panes (default: false)
   sidebar = false,      -- can modify sidebar (default: false)
   prompt = true,        -- can ask user for input (default: true)
@@ -133,12 +150,12 @@ agent_permissions = {
 ```lua
 -- In config.lua
 agent_permissions = {
-  self = true,          -- can set own title, status, color (always allowed)
+  self = true,          -- can set own title, status, color, badge (always allowed)
   notify = true,        -- can send notifications (default: true)
   prompt = true,        -- can prompt user for input (default: true)
   pane_create = false,  -- can open new panes (default: false)
   pane_read = false,    -- can read other panes' output (default: false)
-  pane_input = false,   -- can send input to other panes (default: false)
+  pane_input = false,   -- can send-text/send-keys/send-input to other panes (default: false)
   pane_close = false,   -- can close panes (default: false)
   sidebar = false,      -- can modify sidebar (default: false)
 }
@@ -217,7 +234,7 @@ oakterm ctl self set-title "Analyzing codebase"
 oakterm ctl self set-progress 50
 oakterm ctl self set-title "Writing tests"
 # ... does more work ...
-oakterm ctl self set-status done
+oakterm ctl self set-status done --outcome success
 oakterm ctl self set-badge "4 files, 12 tests"
 oakterm ctl notify "feat/auth complete" --level success
 ```
@@ -228,8 +245,8 @@ The sidebar and tab automatically reflect these updates in real-time.
 
 ```bash
 oakterm ctl pane create --drawer bottom --command "npm test"
-# waits for tests...
-TEST_OUTPUT=$(oakterm ctl pane output $TEST_PANE --lines 5)
+oakterm ctl wait status $TEST_PANE --status done --timeout 60000
+TEST_OUTPUT=$(oakterm ctl pane read $TEST_PANE --lines 5)
 # reads results, continues working
 ```
 
@@ -261,6 +278,8 @@ oakterm ctl notify "Dev environment ready"
 ## Related Docs
 
 - [ADR-0021: Agent Control API](../adrs/0021-agent-control-api.md) — the decision: CLI over MCP, and the permission/security model
+- [ADR-0023: Agent State Vocabulary](../adrs/0023-agent-state-vocabulary.md) — the lifecycle states `set-status` takes and the outcome field `done` carries
+- [ADR-0024: Agent State Sources](../adrs/0024-agent-state-sources.md) — precedence rules self-report participates in; scopes `pane release` to hook-claimed panes
 - [Agent Management](07-agent-management.md) — the plugin that manages agent lifecycle
 - [Sidebar](04-sidebar.md) — where agent status appears
 - [Security](21-security.md) — permission model principles

--- a/docs/ideas/34-notifications.md
+++ b/docs/ideas/34-notifications.md
@@ -16,15 +16,17 @@ Referenced in 10+ docs but never fully specced. There are three notification sur
 
 The primary notification surface. Badges on sidebar entries show state at a glance without interrupting you.
 
-| Badge | Meaning                 | Set by                                  |
-| ----- | ----------------------- | --------------------------------------- |
-| ⟳     | Working                 | agent-manager, watcher                  |
-| ❓    | Needs input/approval    | agent-manager                           |
-| ✓     | Done/success            | agent-manager, watcher                  |
-| ✗     | Error/failed            | agent-manager, service-monitor, watcher |
-| ⚠     | Warning (memory, crash) | service-monitor, memory alerts          |
+| Badge | Meaning                        | Set by                                  |
+| ----- | ------------------------------ | --------------------------------------- |
+| ⟳     | Working                        | agent-manager, watcher                  |
+| ❓    | Blocked (needs input/approval) | agent-manager                           |
+| ✓     | Done + success                 | agent-manager, watcher                  |
+| ✗     | Done + error / failed          | agent-manager, service-monitor, watcher |
+| ⚠     | Warning (memory, crash)        | service-monitor, memory alerts          |
 
 These are passive — you see them when you glance at the sidebar. No popup, no sound, no interruption.
+
+For agent-manager entries, these badges are [ADR-0023](../adrs/0023-agent-state-vocabulary.md)'s lifecycle state + outcome (`working`, `blocked`, `done`+`success`/`error`/`cancelled`); watcher and service-monitor keep their own independent meaning for the same glyph — the warnings tier and non-agent badges are unchanged by ADR-0023.
 
 ### 2. In-Terminal Notifications (banners)
 
@@ -80,12 +82,12 @@ Event (agent done, test failed, etc.)
 
 Priority order:
 
-1. Errors (✗)
-2. Needs input (❓)
+1. Errors (✗) — for agent panes, `done`+`error` ([ADR-0023](../adrs/0023-agent-state-vocabulary.md)); never ages out of the cycle.
+2. Needs input (❓) — for agent panes, `blocked`; never ages out.
 3. Warnings (⚠)
-4. Done (✓) — only if recent and unacknowledged
+4. Done (✓) — only if recent and unacknowledged; for agent panes, `done`+`success` or `done`+`cancelled` age out of this tier over time even if never acknowledged, while `done`+`error` (tier 1) and `blocked` (tier 2) never do.
 
-Pressing `Cmd+Shift+U` focuses the next pane in the cycle. The badge clears when you've viewed the pane.
+Pressing `Cmd+Shift+U` focuses the next pane in the cycle. Acknowledgment ("seen") is daemon-global: viewing the pane from any client — desktop, a second window, a future remote client — clears the badge everywhere, not just for the client that looked (ADR-0023).
 
 ## Notification History
 
@@ -173,6 +175,7 @@ notify.send(Notification {
 
 - [Sidebar](04-sidebar.md) — badge display
 - [Agent Management](07-agent-management.md) — agent state notifications
+- [ADR-0023](../adrs/0023-agent-state-vocabulary.md) — agent lifecycle state + outcome, acknowledgment, and attention-cycle ordering
 - [Shell Integration](18-shell-integration.md) — process completion notifications
 - [Agent Control API](32-agent-control-api.md) — `oakterm ctl notify`
 - [Accessibility](17-accessibility.md) — screen reader announcements, sound cue plugin

--- a/docs/ideas/39-agent-protocol.md
+++ b/docs/ideas/39-agent-protocol.md
@@ -111,7 +111,7 @@ ACP slots between three existing concerns:
 - Tool-call rendering and permission prompts as native UI
 - Slash commands routed through the `:` palette
 
-A plain CLI agent without ACP support still works — it's just opaque output. ACP is opt-in per agent.
+A plain CLI agent without ACP support still works — it's just opaque output. ACP is opt-in per agent. This is one instance of [ADR-0024](../adrs/0024-agent-state-sources.md)'s general precedence rule: process detection always owns pane liveness; an ACP session, an agent hook, or a self-report owns semantic state when present; idea 07's screen heuristics are the floor a plain CLI agent falls back to, never a source that overrides a structured one.
 
 **Relationship to [Agent Control API](32-agent-control-api.md).** Idea 32 is the _inverse_ direction: agent → terminal control via `oakterm ctl`. ACP is terminal → agent in a structured way. The two are complementary:
 
@@ -255,6 +255,7 @@ Every question below received a disposition in [ADR-0022](../adrs/0022-agent-int
 - [Configuration](09-config.md) — config syntax for `agent_providers`
 - [Conventions](30-conventions.md) — naming and palette command conventions
 - [ADR-0022: Agent Integration Protocol](../adrs/0022-agent-integration-protocol.md) — the accepted decision that resolves this doc's proposal
+- [ADR-0024: Agent State Sources](../adrs/0024-agent-state-sources.md) — the precedence rule ACP participates in as a tier-2 semantic-state source
 - [ADR-0014: Input Classifier](../adrs/0014-input-classifier.md) — what routes input to ACP in the first place
 - [ADR-0005: Lua Sandboxed Config](../adrs/0005-lua-sandboxed-config.md) — config language used in examples
 - [Warp Architecture Review](../reviews/2026-04-28-210532-warp-architecture-review.md) — gateway-pattern prior art and AGPL constraint

--- a/docs/specs/0005-lua-config-runtime.md
+++ b/docs/specs/0005-lua-config-runtime.md
@@ -3,7 +3,7 @@ spec: '0005'
 title: Lua Config Runtime
 status: complete
 date: 2026-03-27
-adrs: ['0005']
+adrs: ['0005', '0011']
 tags: [config, core]
 ---
 
@@ -171,19 +171,34 @@ oakterm.config.window_decorations = "full"
 oakterm.config.confirm_close_process = true
 
 -- Phase 1: Multiplexer config (ADR-0011, Spec-0007, Spec-0008, Spec-0010)
--- NOT YET IMPLEMENTED. The current runtime treats unknown keys as hard errors,
--- so setting any of the keys below raises a config error until Phase 1 lands.
 oakterm.config.oak_mod = "ctrl+shift"       -- Linux default; "super" on macOS (super = Cmd key)
 oakterm.config.leader = nil                  -- optional: { key = "ctrl+b", timeout = 1000 }
-oakterm.config.copy_mode_keybinds = "vim"    -- "vim", "emacs", or "basic"
 oakterm.config.status_bar = true
 oakterm.config.status_bar_position = "bottom" -- "top" or "bottom"
-oakterm.config.restartable_commands = {}     -- list of command prefixes to restore on session load
+
+-- NOT YET IMPLEMENTED. The current runtime treats unknown keys as hard errors,
+-- so setting either key below raises a config error until its feature lands.
+oakterm.config.copy_mode_keybinds = "vim"    -- "vim", "emacs", or "basic" (ships with copy mode, TREK-112/113)
+oakterm.config.restartable_commands = {}     -- list of command prefixes to restore on session load (Spec-0010)
 ```
 
 The `oakterm.config` table is implemented as a **proxy table**: an empty table with `__newindex` and `__index` on its metatable, backed by a hidden storage table. Every write routes through `__newindex`, which validates the key. The `raw*` functions that could bypass the metamethods (`rawset`, `rawget`, `rawequal`, `rawlen`) are removed from the sandbox (see above), so there is no way to write past the validation. The metatable has `__metatable` set to a string, preventing `getmetatable`/`setmetatable` from inspecting or replacing the protection.
 
 The `__newindex` metamethod validates keys against the known config schema. Setting an unknown key (e.g., `oakterm.config.font_szie = 14`) raises an immediate error with a "did you mean?" suggestion if a close match exists.
+
+#### `oak_mod` and `leader` (ADR-0011)
+
+`oak_mod` is validated as a modifier-only combo (`ModifierSet::parse`): one or more of `ctrl`/`control`, `alt`/`option`/`opt`, `shift`, `super`/`cmd`/`command`/`win`, joined with `+`, no duplicates. Default is the platform value — `"ctrl+shift"` on Linux/Windows, `"super"` on macOS. An invalid combo (unknown modifier, a non-modifier token, duplicates) raises a config error immediately.
+
+`leader` is `nil` (disabled, the default) or a table `{ key = <chord string>, timeout = <positive integer ms> }`:
+
+- `key` parses as an ordinary key chord (no `oak_mod` token — the leader chord itself is fixed, not `oak_mod`-relative).
+- `timeout` defaults to `1000` when omitted; it must be a positive integer number of milliseconds. Zero, negative, or fractional values raise a config error (a `0ms` follow-up window would silently disable the leader layer).
+
+Two keybind-string tokens read these values at config-extraction time:
+
+- `oak_mod+<rest>` expands `oak_mod` to its configured modifier set. Expansion happens against the config's **final** value regardless of where in the file `oakterm.config.oak_mod` is assigned relative to the `oakterm.keybind(...)` calls that use it — `oak_mod` is order-independent in the config file. An explicit modifier that overlaps `oak_mod`'s set (e.g. `oak_mod+shift+up` when `oak_mod` already contains `shift`) folds silently instead of erroring; duplicate explicit modifiers still error.
+- `leader+<rest>` routes the binding into a separate leader table, matched only while a leader press is pending, instead of the default keybind table. The `<rest>` may itself use `oak_mod` (`leader+oak_mod+d`). Registering a `leader+` binding while `leader` is unset does not error, but the binding can never fire — the runtime warns.
 
 #### `oakterm.action` Table
 

--- a/docs/specs/0009-command-palette-status-bar.md
+++ b/docs/specs/0009-command-palette-status-bar.md
@@ -181,59 +181,73 @@ Non-performable actions are excluded from results (checked via `is_performable`)
 
 ### Status Bar
 
-A single-line bar at the bottom of the window.
+A single-line bar at the configured edge of the window (`status_bar_position`).
+
+As built, the bar is not a segment list — the `left`/`center`/`right: Vec<StatusSegment>` shape this spec originally sketched was never implemented. Instead `StatusContent<'a>` (`crates/oakterm/src/status_bar.rs`) is a flat struct of borrowed fields, and a pure `layout_row` function maps it directly to sparse `(col, StatusCell)` cells for a fixed built-in layout:
 
 ```rust
-struct StatusBar {
-    /// Left-aligned segments.
-    left: Vec<StatusSegment>,
-
-    /// Center-aligned segments.
-    center: Vec<StatusSegment>,
-
-    /// Right-aligned segments.
-    right: Vec<StatusSegment>,
+/// Everything the status bar displays, borrowed from live GUI state.
+struct StatusContent<'a> {
+    /// Active mode name (e.g. "COPY"); `None` in normal mode hides the
+    /// indicator.
+    mode: Option<&'a str>,
+    workspace: &'a str,
+    tabs: &'a [TabInfo],
+    active_tab: Option<u32>,
+    pane_title: &'a str,
+    /// Pre-formatted wall-clock text (e.g. "14:30").
+    clock: &'a str,
 }
 
-enum StatusSegment {
-    /// Current mode (e.g., "COPY", "RESIZE"). Hidden in normal mode.
-    Mode(String),
-
-    /// Active workspace name.
-    Workspace(String),
-
-    /// Tab list with active indicator.
-    Tabs(Vec<TabInfo>),
-
-    /// Focused pane title.
-    PaneTitle(String),
-
-    /// Current time.
-    Clock(String),
-
-    /// Static text.
-    Text(String),
-}
-
+/// Reused from the tab bar (`tab_bar::TabInfo`), mirroring the per-tab
+/// fields of Spec-0001's `TabList` (0xB0) wire message. No `active`
+/// field — activeness comes from `StatusContent::active_tab`, not
+/// per-tab state.
 struct TabInfo {
+    tab_id: u32,
+    focused_pane: u32,
     name: String,
-    active: bool,
-    index: usize,
 }
+
+/// Which segment a cell belongs to, for styling.
+enum SegmentKind {
+    Mode,
+    Workspace,
+    Tab { active: bool },
+    Title,
+    Clock,
+}
+
+struct StatusCell {
+    ch: char,
+    kind: SegmentKind,
+}
+
+/// Lay out one status bar row: sparse `(col, cell)` pairs in column order.
+fn layout_row(content: &StatusContent, cols: u16) -> Vec<(u16, StatusCell)>;
 ```
 
-**Default layout:**
+Center-aligned content and general segment extensibility never shipped; that's Phase-2 plugin work, not this spec's built-in bar.
+
+**Layout algorithm.** The right side places first, then the left side fills up to it:
+
+- **Right:** the clock is all-or-nothing at the right edge — it renders only if it fits whole in `cols`, never truncated. The focused pane title sits before it with a 2-column gap, truncating (from the tail) to whatever space remains.
+- **Left:** mode indicator (only when `content.mode` is `Some`), workspace name, a `" |"` separator, then the tab strip — reusing `tab_bar::layout_strip`/`strip_cells` directly rather than a second implementation. The left side clips one column short of wherever the right side starts, so the two sides never touch even under extreme narrowing.
+
+**Default layout** (worked example, `TabInfo` reused from the tab bar):
 
 ```text
-[COPY] work | 1:code  2:git  3:logs                      ~/project  14:30
- mode  ws     tabs                                        pane title  clock
+[COPY] work |  1:code   2:git   3:logs                   ~/project  14:30
+mode   ws               tabs                             pane title clock
 ```
 
-- Left: mode indicator (only when in copy/resize mode), workspace name, tab list.
-- Right: focused pane title (truncated to fit), clock.
-- Center: empty by default.
+**Rendering.** The bar's background underlay spans the full window width; the text grid itself insets one cell from each window edge (`crates/oakterm/src/frame.rs::assemble_status_bar`).
 
-**Discoverability:** When a mode is active (copy, resize), the status bar shows available keys:
+**Clock repaint.** No separate timer: `App` arms a `clock_deadline` at the next minute boundary and merges it into the same `next_wakeup` deadline selection the cursor blink timer uses, so one wakeup mechanism drives both. The deadline clears when it fires and is re-armed after each frame, so drift never accumulates.
+
+**Mode indicator and hint text — pending.** `SegmentKind::Mode` and the `Option<&str>` plumbing exist and render correctly when given a mode, but nothing sets `mode` to `Some` yet: no copy mode or resize mode has landed, so `assemble_status_bar_chrome` always passes `mode: None`. The discoverability hint line and `status_bar_hint_duration` below are not implemented; they ship together with copy mode and resize mode (TREK-110–113/124).
+
+**Discoverability (pending, TREK-110–113/124):** When a mode is active (copy, resize), the status bar will show available keys:
 
 ```text
 [COPY] j/k:move  v:select  y:yank  /:search  q:quit
@@ -266,25 +280,27 @@ Recents are session-only: they are not persisted across restarts.
 
 ### Status Bar Updates
 
-The status bar re-renders when:
+The bar is reassembled every frame from live state (`self.tabs`, `self.panes[focused].title`, `status_bar::clock_text()`), so it stays current without a dedicated dirty-tracking path. What actually drives a new frame:
 
-- The active mode changes (enter/exit copy mode, resize mode).
-- The focused pane changes (title, cwd).
+- The focused pane's title changes (OSC-set title triggers the normal redraw path).
 - A tab is created, closed, renamed, or switched.
 - The active workspace changes.
-- The clock ticks (once per minute).
+- The clock's minute-boundary deadline fires (`clock_deadline`, merged with the blink timer into `next_wakeup`).
+- Enter/exit copy mode or resize mode — **pending**, since neither mode exists yet (TREK-110–113/124); today `mode` is always `None`.
 
-The status bar does not re-render on pane content changes (that would be every frame).
+**Not implemented:** a focused-pane-cwd trigger. `pane_title` reflects only the OSC-set title; the client does not track focused-pane cwd, so a cwd-only change (no title change) does not re-render the bar. The gap is two-fold: `pane.cwd_changed` is declared in the Lua event set (Spec-0005) but nothing in the daemon or client fires it yet, and the client has no focused-pane cwd tracking to re-render from even once it does.
+
+The status bar does not re-render on pane content changes (that would be every frame from PTY output alone).
 
 ### Configuration
 
 ```lua
 oakterm.config.status_bar = true           -- show/hide
 oakterm.config.status_bar_position = "bottom"  -- "top" or "bottom"
-oakterm.config.status_bar_hint_duration = "2w" -- auto-hide key hints after 2 weeks
+oakterm.config.status_bar_hint_duration = "2w" -- auto-hide key hints after 2 weeks (pending, TREK-110–113/124)
 ```
 
-Status bar configuration is part of Spec-0005 (Lua Config Runtime) addendum.
+`status_bar` and `status_bar_position` ship as specified (`oakterm_config::schema`, validated in `proxy.rs`; default `status_bar = true`, `status_bar_position = "bottom"`) — part of Spec-0005 (Lua Config Runtime) addendum. `status_bar_hint_duration` is not implemented — it ships with the copy/resize mode hint text above.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Three docs-only write-back tasks, one per commit:

- **TREK-183**: sidebar, notifications, agent-management, and agent-control-api idea docs absorb ADR-0023's state vocabulary (five lifecycle states + outcome, daemon-global acknowledgment, attention-cycle ordering) and ADR-0024's per-claim three-tier source precedence; agent-control-api gains the herdr-derived ctl primitives with `set-status` narrowed to agent-settable states
- **TREK-283**: Spec-0009 updated to the as-built status bar (StatusContent + layout_row, placement algorithm, clock deadline, pending items marked with their tasks)
- **TREK-288**: Spec-0005 + ADR-0011 record the shipped oak_mod/leader behavior (config-extraction-time expansion, overlap folding, leader namespace, live default set)

## Review

Codex + code-reviewer pass; 14 findings fixed (including an ADR-0024 precedence-qualifier regression and `set-status` accepting daemon-owned states). Every as-built claim verified against the code before writing.

## Test plan

- `mise run fmt` and `mise run lint` clean; all cross-references resolve

TREK-183, TREK-283, TREK-288