### PR TITLE
fix(core): move archive reads off the pane lock and tokio workers

### DIFF
--- a/crates/oakterm-daemon/Cargo.toml
+++ b/crates/oakterm-daemon/Cargo.toml
@@ -24,6 +24,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
+oakterm-terminal = { path = "../oakterm-terminal", features = ["test-hooks"] }
 tempfile = "3.27.0"
 
 [build-dependencies]

--- a/crates/oakterm-daemon/src/requests/copy_mode.rs
+++ b/crates/oakterm-daemon/src/requests/copy_mode.rs
@@ -363,7 +363,7 @@ async fn resolve_yank(
 
     let archive_start = plan.first_row.min(layout.archived);
     let archive_end = plan.last_row.saturating_add(1).min(layout.archived);
-    let (first_rows, _) = read_archive_span(
+    let (first_rows, mut archive_shortfall) = read_archive_span(
         conn_id,
         req.pane_id,
         &access,
@@ -392,7 +392,7 @@ async fn resolve_yank(
         // Nothing migrated, which is the common case: assemble under the
         // guard already held rather than dropping and re-taking it.
         if end <= top_up_start {
-            assembled = Some(collect_yank_text(&pane, &plan, &window));
+            assembled = Some(collect_yank_text(&pane, &plan, &window, archive_shortfall));
         }
         end
     };
@@ -400,7 +400,7 @@ async fn resolve_yank(
     let (text, missing) = if let Some(done) = assembled {
         done
     } else {
-        let (extra, recovered) = read_archive_span(
+        let (extra, top_up_shortfall) = read_archive_span(
             conn_id,
             req.pane_id,
             &access,
@@ -411,18 +411,20 @@ async fn resolve_yank(
         .await
         .map_err(YankFailure::Archive)?;
         window.extend(top_up_start, extra);
+        archive_shortfall += top_up_shortfall;
+        let requested = top_up_end - top_up_start;
         debug!(
             conn_id,
             pane_id = req.pane_id,
-            requested = top_up_end - top_up_start,
-            recovered,
+            requested,
+            recovered = requested - top_up_shortfall,
             "rows migrated into the archive mid-yank; topped up"
         );
         let pane = lock_live_pane(panes, req.pane_id).await.ok_or_else(|| {
             warn!(conn_id, pane_id = req.pane_id, "pane closed mid-yank");
             YankFailure::UnknownPane
         })?;
-        collect_yank_text(&pane, &plan, &window)
+        collect_yank_text(&pane, &plan, &window, archive_shortfall)
     };
     if let Some(missing) = missing {
         warn_missing_rows(conn_id, req.pane_id, missing, access.reader().cloned());
@@ -438,12 +440,19 @@ fn collect_yank_text(
     pane: &PaneState,
     plan: &YankPlan,
     archive: &ArchiveWindow,
+    archive_shortfall: u64,
 ) -> (String, Option<MissingRows>) {
     let layout = HistoryLayout::of(pane);
     let buf = pane.screens.scrollback();
     let grid = pane.screens.active_grid();
 
-    let mut missing = MissingRows::default();
+    // Seeded rather than counted below: rows the archive could not supply
+    // were blank-filled inside the window, so every lookup for them
+    // succeeds and none of them would ever be counted here.
+    let mut missing = MissingRows {
+        archive_gap: archive_shortfall,
+        ..MissingRows::default()
+    };
     let mut rows: Vec<(u64, Option<&Row>)> = Vec::new();
     for abs in plan.first_row..=plan.last_row {
         let row = if abs < layout.archived {
@@ -568,7 +577,10 @@ impl ArchiveWindow {
     }
 }
 
-/// Returns the aligned rows and how many the archive actually supplied.
+/// Returns the aligned rows and how many of them are blank fill the
+/// archive could not supply. That shortfall is invisible downstream —
+/// blank fill is indistinguishable from a blank terminal row — so it has
+/// to travel with the rows.
 ///
 /// One read, not a chunk loop: `ArchiveCore::read_range` pulls every
 /// touched segment file whole, so splitting a span only re-reads segments.
@@ -579,13 +591,14 @@ async fn read_archive_span(
     start: u64,
     end: u64,
     cols: usize,
-) -> Result<(Vec<Row>, usize), &'static str> {
+) -> Result<(Vec<Row>, u64), &'static str> {
     if start >= end {
         return Ok((Vec::new(), 0));
     }
     let count = usize::try_from(end - start).unwrap_or(usize::MAX);
     let found = read_archive_rows(conn_id, pane_id, access.clone(), start, count).await?;
-    Ok(align_archive_rows(found, start, count, cols))
+    let (rows, supplied) = align_archive_rows(found, start, count, cols);
+    Ok((rows, u64::try_from(count - supplied).unwrap_or(u64::MAX)))
 }
 
 /// Release every pin this client holds, across all panes. Copy-mode pins
@@ -1508,6 +1521,63 @@ mod tests {
     /// Covered here rather than through a concurrent yank because an empty
     /// span issues no read at all, leaving nothing to synchronise on — a
     /// timing-based version could only ever be hopeful.
+    /// A row the archive could not supply is blank-filled *inside* the
+    /// window, so `ArchiveWindow::get` answers `Some(blank)` for it and no
+    /// lookup ever misses. Counting only lookup misses therefore hides the
+    /// Spec-0004 overload loss the counter exists to report — the shortfall
+    /// has to be carried from the read itself.
+    #[tokio::test]
+    async fn an_in_window_archive_shortfall_counts_as_a_gap() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+        assert_eq!(HistoryLayout::of(&pane).archived, 2, "rows 0..2 archived");
+
+        // The read covered rows 0 and 1 but the archive supplied only row
+        // 0; row 1 came back as blank fill, a shortfall of one.
+        let plan = plan_yank(4, &req(-4, 0, -3, 0, CopySelectionType::Line));
+        let window = ArchiveWindow::new(0, vec![row_from("one", COLS), Row::new(COLS)]);
+
+        let (_, missing) = collect_yank_text(&pane, &plan, &window, 1);
+
+        let missing = missing.expect("a blank-filled archive row is a missing row");
+        assert_eq!(missing.archive_gap, 1);
+        assert_eq!(missing.index_miss, 0, "not a planning bug");
+        assert_eq!(missing.pruned, 0, "the archive had these rows' indices");
+    }
+
+    /// The shortfall and the lookup miss count different rows, so a row
+    /// must not reach both: blank fill lands inside the window and is
+    /// carried by the shortfall, while a row that migrated in after the
+    /// top-up lies outside it and is caught by the miss.
+    #[tokio::test]
+    async fn a_blank_filled_row_is_not_counted_twice() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lines = ["one", "two", "three", "four", "five", "six"];
+        let (panes, pane_id) = pane_with_archived_prefix(dir.path(), &lines, 2).await;
+        let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+        assert!(
+            HistoryLayout::of(&pane).archived > 2,
+            "row 2 must sit in the archive tier"
+        );
+
+        // Window covers rows 0 and 1 with one blank fill; row 2 is
+        // archived but was never collected.
+        let base = u64::try_from(lines.len()).expect("row count");
+        let plan = plan_yank(base, &req(-6, 0, -4, 0, CopySelectionType::Line));
+        assert_eq!((plan.first_row, plan.last_row), (0, 2));
+        let window = ArchiveWindow::new(0, vec![row_from("one", COLS), Row::new(COLS)]);
+
+        let (_, missing) = collect_yank_text(&pane, &plan, &window, 1);
+
+        let missing = missing.expect("missing rows");
+        assert_eq!(
+            missing.archive_gap, 2,
+            "one blank fill plus one uncollected row, each counted once"
+        );
+    }
+
     #[test]
     fn an_empty_archive_window_rebases_onto_the_top_up() {
         let mut window = ArchiveWindow::new(7, Vec::new());

--- a/crates/oakterm-daemon/src/requests/copy_mode.rs
+++ b/crates/oakterm-daemon/src/requests/copy_mode.rs
@@ -1,9 +1,7 @@
 //! Copy mode family: `EnterCopyMode` (0x97), `ExitCopyMode` (0x98), and
 //! `YankSelection` (0x99) / `YankResponse` (0x9A). See Spec-0008.
 
-use super::scrollback::{
-    HistoryLayout, MAX_SCROLLBACK_ROWS_PER_REQUEST, align_archive_rows, read_archive_rows,
-};
+use super::scrollback::{ArchiveAccess, HistoryLayout, align_archive_rows, read_archive_rows};
 use super::{RequestResult, make_error_response};
 use crate::pane::{PaneManager, PaneState, SharedPane, lock_live_pane};
 use oakterm_protocol::frame::{Frame, MAX_PAYLOAD};
@@ -11,7 +9,7 @@ use oakterm_protocol::message::{
     CopyMode, CopySelectionType, ErrorCode, YankResponse, YankSelection,
 };
 use oakterm_terminal::grid::row::Row;
-use oakterm_terminal::scroll::archive_manager::ArchiveManager;
+use oakterm_terminal::scroll::archive_manager::{ArchiveManager, ArchiveReader};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{debug, error, warn};
@@ -333,8 +331,8 @@ enum YankFailure {
 }
 
 /// Planning, the archive read, and assembly each take the pane lock
-/// separately: the archive read is blocking (TREK-197) and holding the
-/// lock across a large one would stall this pane's PTY reader.
+/// separately: the archive read blocks until the writer answers (TREK-197)
+/// and holding the lock across it would stall this pane's PTY reader.
 async fn resolve_yank(
     conn_id: u64,
     req: &YankSelection,
@@ -349,13 +347,14 @@ async fn resolve_yank(
             .saturating_add(u64::from(pane.screens.active_grid().rows));
         let layout = HistoryLayout::of(&pane);
         let cols = usize::from(pane.screens.active_grid().cols);
+        let access = ArchiveAccess::of(&pane);
         plan_yank(pane.copy_mode_base(conn_id), req)
             .clamped_to(grid_end)
-            .map(|plan| (plan, layout, cols))
+            .map(|plan| (plan, layout, cols, access))
     };
 
     // The whole selection sits past the last row that exists.
-    let Some((plan, layout, cols)) = planned else {
+    let Some((plan, layout, cols, access)) = planned else {
         return Ok(String::new());
     };
     if plan.row_count() > MAX_YANK_ROWS {
@@ -364,29 +363,71 @@ async fn resolve_yank(
 
     let archive_start = plan.first_row.min(layout.archived);
     let archive_end = plan.last_row.saturating_add(1).min(layout.archived);
-    let archive_rows = read_archive_chunked(
+    let (first_rows, _) = read_archive_span(
         conn_id,
         req.pane_id,
-        panes,
+        &access,
         archive_start,
         archive_end,
         cols,
     )
     .await
     .map_err(YankFailure::Archive)?;
+    let mut window = ArchiveWindow::new(archive_start, first_rows);
 
-    let pane = lock_live_pane(panes, req.pane_id).await.ok_or_else(|| {
-        warn!(conn_id, pane_id = req.pane_id, "pane closed mid-yank");
-        YankFailure::UnknownPane
-    })?;
-    Ok(collect_yank_text(
-        conn_id,
-        req.pane_id,
-        &pane,
-        &plan,
-        &archive_rows,
-        archive_start,
-    ))
+    // Rows can migrate out of the hot buffer and into the archive while
+    // the read above runs, landing outside the window it covered. One
+    // top-up read collects them; rows that migrate after it blank-fill as
+    // before, which is what bounds this to a single extra read.
+    let top_up_start = archive_end.max(plan.first_row);
+    let mut assembled = None;
+    let top_up_end = {
+        let pane = lock_live_pane(panes, req.pane_id).await.ok_or_else(|| {
+            warn!(conn_id, pane_id = req.pane_id, "pane closed mid-yank");
+            YankFailure::UnknownPane
+        })?;
+        let end = HistoryLayout::of(&pane)
+            .archived
+            .min(plan.last_row.saturating_add(1));
+        // Nothing migrated, which is the common case: assemble under the
+        // guard already held rather than dropping and re-taking it.
+        if end <= top_up_start {
+            assembled = Some(collect_yank_text(&pane, &plan, &window));
+        }
+        end
+    };
+
+    let (text, missing) = if let Some(done) = assembled {
+        done
+    } else {
+        let (extra, recovered) = read_archive_span(
+            conn_id,
+            req.pane_id,
+            &access,
+            top_up_start,
+            top_up_end,
+            cols,
+        )
+        .await
+        .map_err(YankFailure::Archive)?;
+        window.extend(top_up_start, extra);
+        debug!(
+            conn_id,
+            pane_id = req.pane_id,
+            requested = top_up_end - top_up_start,
+            recovered,
+            "rows migrated into the archive mid-yank; topped up"
+        );
+        let pane = lock_live_pane(panes, req.pane_id).await.ok_or_else(|| {
+            warn!(conn_id, pane_id = req.pane_id, "pane closed mid-yank");
+            YankFailure::UnknownPane
+        })?;
+        collect_yank_text(&pane, &plan, &window)
+    };
+    if let Some(missing) = missing {
+        warn_missing_rows(conn_id, req.pane_id, missing, access.reader().cloned());
+    }
+    Ok(text)
 }
 
 /// Walk the plan's rows across the tiers they can live in — disk archive,
@@ -394,89 +435,157 @@ async fn resolve_yank(
 /// order, which is also ascending absolute index. The plan is already
 /// clamped to rows that exist.
 fn collect_yank_text(
-    conn_id: u64,
-    pane_id: u32,
     pane: &PaneState,
     plan: &YankPlan,
-    archive_rows: &[Row],
-    archive_start: u64,
-) -> String {
+    archive: &ArchiveWindow,
+) -> (String, Option<MissingRows>) {
     let layout = HistoryLayout::of(pane);
     let buf = pane.screens.scrollback();
     let grid = pane.screens.active_grid();
 
-    let mut missing = 0u64;
+    let mut missing = MissingRows::default();
     let mut rows: Vec<(u64, Option<&Row>)> = Vec::new();
     for abs in plan.first_row..=plan.last_row {
         let row = if abs < layout.archived {
-            archive_rows.get(usize::try_from(abs - archive_start).unwrap_or(usize::MAX))
+            let row = archive.get(abs);
+            missing.archive_gap += u64::from(row.is_none());
+            row
         } else if abs < layout.hot_first {
+            missing.pruned += 1;
             None
         } else if abs < layout.pushed {
-            buf.get(usize::try_from(abs - layout.hot_first).unwrap_or(usize::MAX))
+            let row = buf.get(usize::try_from(abs - layout.hot_first).unwrap_or(usize::MAX));
+            missing.index_miss += u64::from(row.is_none());
+            row
         } else {
-            grid.lines
-                .get(usize::try_from(abs - layout.pushed).unwrap_or(usize::MAX))
+            let row = grid
+                .lines
+                .get(usize::try_from(abs - layout.pushed).unwrap_or(usize::MAX));
+            missing.index_miss += u64::from(row.is_none());
+            row
         };
-        missing += u64::from(row.is_none());
         rows.push((abs, row));
     }
-    if missing > 0 {
-        // Distinguish the two ways a row can be absent so the log points
-        // at the right cause: an unarchived prune versus rows the archive
-        // dropped under load (Spec-0004 overload policy).
-        let lost = pane
+    if missing.total() > 0 {
+        missing.dropped = pane
             .screens
             .archive()
-            .map_or(0, ArchiveManager::lost_rows)
-            .max(
-                pane.screens
-                    .archive()
-                    .map_or(0, ArchiveManager::dropped_rows),
-            );
+            .map_or(0, ArchiveManager::dropped_rows);
+    }
+    let missing = (missing.total() > 0).then_some(missing);
+    (extract_text(plan, rows.into_iter()), missing)
+}
+
+/// Rows the assembled text could not source, split by cause — they mean
+/// different things and only one is normal. `pruned` is a permanent hole
+/// (pruned with no archive attached); `archive_gap` is a Spec-0004
+/// overload loss or a row that migrated in after the top-up; `index_miss`
+/// is a row the plan claimed exists in a live tier, which is a bug here,
+/// not data loss. `dropped` is the enqueue-side loss count, a free field
+/// read taken under the lock for context.
+#[derive(Clone, Copy, Default)]
+struct MissingRows {
+    archive_gap: u64,
+    pruned: u64,
+    index_miss: u64,
+    dropped: u64,
+}
+
+impl MissingRows {
+    fn total(&self) -> u64 {
+        self.archive_gap + self.pruned + self.index_miss
+    }
+}
+
+/// Report blank-filled rows without making the client wait for it.
+///
+/// The writer-side loss count is a mailbox round-trip that can take the
+/// full query timeout, and this runs on the response path — awaiting it
+/// would delay a `YankResponse` by up to 10s to decorate a log line. A
+/// detached task can lose the line if the runtime shuts down first, which
+/// is the right trade for a diagnostic: at that point the daemon is
+/// exiting anyway.
+fn warn_missing_rows(
+    conn_id: u64,
+    pane_id: u32,
+    missing: MissingRows,
+    reader: Option<ArchiveReader>,
+) {
+    tokio::spawn(async move {
+        let writer_lost = match reader {
+            Some(reader) => {
+                match tokio::task::spawn_blocking(move || reader.writer_lost_rows()).await {
+                    Ok(lost) => lost,
+                    Err(e) => {
+                        warn!(conn_id, pane_id, error = %e, "archive stats task failed");
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
         warn!(
             conn_id,
             pane_id,
-            missing,
-            archive_lost_rows = lost,
-            "yank crossed rows no longer in history; blank-filled"
+            archive_gap = missing.archive_gap,
+            pruned_before_archive = missing.pruned,
+            index_miss = missing.index_miss,
+            archive_dropped_rows = missing.dropped,
+            archive_writer_lost_rows = ?writer_lost,
+            "yank could not source every row; blank-filled"
         );
-    }
-    extract_text(plan, rows.into_iter())
+    });
 }
 
-/// Read `[start, end)` from the archive in bounded chunks, taking and
-/// releasing the pane lock around each one so a large yank cannot stall
-/// the pane's PTY reader for the whole read. Safe to interleave because
-/// absolute row indices never shift (see `HistoryLayout`), so a chunk
-/// fetched earlier stays valid.
+/// Archive rows for one yank, plus the absolute index of the first entry.
+/// A wrong origin shifts every row and yields wrong text with no error.
+struct ArchiveWindow {
+    rows: Vec<Row>,
+    start: u64,
+}
+
+impl ArchiveWindow {
+    fn new(start: u64, rows: Vec<Row>) -> Self {
+        Self { rows, start }
+    }
+
+    /// Append rows read from absolute index `from`, rebasing if nothing
+    /// has been collected yet.
+    fn extend(&mut self, from: u64, rows: Vec<Row>) {
+        if self.rows.is_empty() {
+            self.start = from;
+        }
+        assert!(
+            from.checked_sub(self.start) == u64::try_from(self.rows.len()).ok(),
+            "an archive window must stay contiguous"
+        );
+        self.rows.extend(rows);
+    }
+
+    fn get(&self, abs: u64) -> Option<&Row> {
+        let offset = abs.checked_sub(self.start)?;
+        self.rows.get(usize::try_from(offset).ok()?)
+    }
+}
+
+/// Returns the aligned rows and how many the archive actually supplied.
 ///
-/// A row that migrates from the hot buffer into the archive *during* the
-/// read lands outside this window and blank-fills — it fails safe rather
-/// than returning the wrong row, and is warned by `collect_yank_text`.
-async fn read_archive_chunked(
+/// One read, not a chunk loop: `ArchiveCore::read_range` pulls every
+/// touched segment file whole, so splitting a span only re-reads segments.
+async fn read_archive_span(
     conn_id: u64,
     pane_id: u32,
-    panes: &Arc<Mutex<PaneManager>>,
+    access: &ArchiveAccess,
     start: u64,
     end: u64,
     cols: usize,
-) -> Result<Vec<Row>, &'static str> {
-    let chunk = u64::from(MAX_SCROLLBACK_ROWS_PER_REQUEST);
-    let mut rows = Vec::new();
-    let mut at = start;
-    while at < end {
-        let count = usize::try_from((end - at).min(chunk)).unwrap_or(usize::MAX);
-        let found = {
-            let Some(pane) = lock_live_pane(panes, pane_id).await else {
-                return Err("pane closed mid-yank");
-            };
-            read_archive_rows(conn_id, pane_id, pane.screens.archive(), at, count)?
-        };
-        rows.extend(align_archive_rows(found, at, count, cols));
-        at += count as u64;
+) -> Result<(Vec<Row>, usize), &'static str> {
+    if start >= end {
+        return Ok((Vec::new(), 0));
     }
-    Ok(rows)
+    let count = usize::try_from(end - start).unwrap_or(usize::MAX);
+    let found = read_archive_rows(conn_id, pane_id, access.clone(), start, count).await?;
+    Ok(align_archive_rows(found, start, count, cols))
 }
 
 /// Release every pin this client holds, across all panes. Copy-mode pins
@@ -498,6 +607,7 @@ pub(crate) async fn release_client_pins(conn_id: u64, panes: &Arc<Mutex<PaneMana
 
 #[cfg(test)]
 mod tests {
+    use super::super::scrollback::tests::await_read_in_flight;
     use super::*;
     use oakterm_protocol::message::{ErrorMessage, MSG_YANK_RESPONSE};
 
@@ -1291,6 +1401,213 @@ mod tests {
             expect_error(yank_selection(1, &frame, &panes).await),
             ErrorCode::InvalidMessage
         );
+    }
+
+    /// Take the pane lock, failing rather than hanging if it is held.
+    /// Without the bound, a lock-held-across-the-read regression deadlocks
+    /// until the archive's 10s query timeout and then trips whichever
+    /// downstream assertion notices first, blaming the wrong thing.
+    async fn lock_pane_promptly(
+        panes: &Arc<Mutex<PaneManager>>,
+        pane_id: u32,
+    ) -> tokio::sync::OwnedMutexGuard<PaneState> {
+        tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            lock_live_pane(panes, pane_id),
+        )
+        .await
+        .expect("pane lock held across the archive read")
+        .expect("pane")
+    }
+
+    /// The yank's *main* archive read must be off the pane lock, not just
+    /// the diagnostic. With the writer parked mid-read the yank cannot
+    /// answer, yet the pane has to stay lockable.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_stalled_yank_read_does_not_hold_the_pane_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        enter_copy_mode(1, &enter_frame(pane_id), &panes).await;
+        let mut stall = {
+            let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens.archive().expect("archive").stall_next_read()
+        };
+
+        let frame = yank_frame(pane_id, req(-4, 0, -1, 0, CopySelectionType::Line));
+        let yank = tokio::spawn({
+            let panes = Arc::clone(&panes);
+            async move { yank_selection(1, &frame, &panes).await }
+        });
+        await_read_in_flight(&mut stall).await;
+
+        assert!(!yank.is_finished(), "the parked read must hold the yank");
+        drop(lock_pane_promptly(&panes, pane_id).await);
+
+        stall.release();
+        assert_eq!(
+            expect_yanked(yank.await.expect("yank task")),
+            "one\ntwo\nthree\nfour"
+        );
+    }
+
+    /// A row can migrate out of the hot buffer and into the archive after
+    /// the yank has planned its read, landing outside the window that read
+    /// covered. It must be topped up, not blank-filled: it is still in
+    /// history, so returning an empty line would lose real output.
+    ///
+    /// The stalled writer holds the first read open; the rows pushed while
+    /// it is parked queue behind it, so the top-up read observes them.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_row_archived_mid_yank_is_topped_up_not_blank_filled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        enter_copy_mode(1, &enter_frame(pane_id), &panes).await;
+        let mut stall = {
+            let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens.archive().expect("archive").stall_next_read()
+        };
+
+        let frame = yank_frame(pane_id, req(-4, 0, -1, 0, CopySelectionType::Line));
+        let yank = tokio::spawn({
+            let panes = Arc::clone(&panes);
+            async move { yank_selection(1, &frame, &panes).await }
+        });
+        // The rendezvous also orders the pushes below *after* the yank's
+        // read: were they to win the race, no top-up would be needed and
+        // the test would exercise nothing.
+        await_read_in_flight(&mut stall).await;
+
+        // "three" and "four" are pruned into the archive while the yank's
+        // first read is still parked.
+        push_scrollback(&panes, pane_id, &["five", "six"]).await;
+        {
+            let pane = lock_pane_promptly(&panes, pane_id).await;
+            let archive = pane.screens.archive().expect("archive");
+            assert_eq!(archive.dropped_rows(), 0, "the mailbox must not overflow");
+            assert!(
+                archive.total_rows_received() > 2,
+                "the pushes must have archived the rows the yank already planned around"
+            );
+        }
+
+        stall.release();
+        assert_eq!(
+            expect_yanked(yank.await.expect("yank task")),
+            "one\ntwo\nthree\nfour"
+        );
+    }
+
+    /// The top-up's other shape, and the one whose failure is silent: the
+    /// first read's span was empty, so the top-up's rows are the first
+    /// thing collected and the window must rebase onto them. Get it wrong
+    /// and every row shifts against its absolute index, yielding
+    /// confidently wrong text with no error anywhere.
+    ///
+    /// Covered here rather than through a concurrent yank because an empty
+    /// span issues no read at all, leaving nothing to synchronise on — a
+    /// timing-based version could only ever be hopeful.
+    #[test]
+    fn an_empty_archive_window_rebases_onto_the_top_up() {
+        let mut window = ArchiveWindow::new(7, Vec::new());
+
+        window.extend(9, vec![row_from("nine", COLS), row_from("ten", COLS)]);
+
+        assert!(window.get(7).is_none(), "the planned origin held nothing");
+        assert!(window.get(8).is_none());
+        assert_eq!(window.get(9).expect("row 9").text_range(0, 4), "nine");
+        assert_eq!(window.get(10).expect("row 10").text_range(0, 3), "ten");
+        assert!(window.get(11).is_none());
+    }
+
+    #[test]
+    fn a_populated_archive_window_extends_without_moving() {
+        let mut window = ArchiveWindow::new(4, vec![row_from("four", COLS)]);
+
+        window.extend(5, vec![row_from("five", COLS)]);
+
+        assert!(window.get(3).is_none(), "nothing lies before the origin");
+        assert_eq!(window.get(4).expect("row 4").text_range(0, 4), "four");
+        assert_eq!(window.get(5).expect("row 5").text_range(0, 4), "five");
+    }
+
+    /// Nothing holds the pane open across the archive read any more, so a
+    /// close landing mid-read must be caught when the yank comes back for
+    /// the lock — an error, never text assembled from a dead pane.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_pane_closed_mid_yank_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        enter_copy_mode(1, &enter_frame(pane_id), &panes).await;
+        let mut stall = {
+            let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens.archive().expect("archive").stall_next_read()
+        };
+
+        let frame = yank_frame(pane_id, req(-4, 0, -1, 0, CopySelectionType::Line));
+        let yank = tokio::spawn({
+            let panes = Arc::clone(&panes);
+            async move { yank_selection(1, &frame, &panes).await }
+        });
+        await_read_in_flight(&mut stall).await;
+
+        lock_pane_promptly(&panes, pane_id).await.closed = true;
+        stall.release();
+
+        assert_eq!(
+            expect_error(yank.await.expect("yank task")),
+            ErrorCode::UnknownPane
+        );
+    }
+
+    /// The missing-rows diagnostic wants a writer round-trip for the
+    /// lost-row count, and a wedged writer makes that round-trip cost the
+    /// full query timeout. This yank reads nothing from disk — its rows
+    /// fell into a gap that predates the archive — so the stalled writer
+    /// can only be reached by the diagnostic, and neither the response nor
+    /// the pane lock may wait on it. A log field is never worth either.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_missing_rows_diagnostic_delays_neither_response_nor_pane() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) = pane_with_scrollback(&["gone"]).await;
+        cap_scrollback_rows(&panes, pane_id, 2).await;
+        push_scrollback(&panes, pane_id, &["a", "b", "c", "keep"]).await;
+        let gate = {
+            let mut pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            // Attached after the prunes, so the lost rows are a permanent
+            // gap and no archive read is planned.
+            pane.screens.set_archive(
+                ArchiveManager::new(dir.path().join("archive"), 1 << 20).expect("archive"),
+            );
+            pane.screens.archive().expect("archive").stall_writer()
+        };
+        enter_copy_mode(1, &enter_frame(pane_id), &panes).await;
+
+        let frame = yank_frame(pane_id, req(-5, 0, -1, 0, CopySelectionType::Line));
+        let answered = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            yank_selection(1, &frame, &panes),
+        )
+        .await
+        .expect("response must not wait on the diagnostic");
+
+        let locked = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            lock_live_pane(&panes, pane_id),
+        )
+        .await;
+        assert!(
+            locked
+                .expect("pane lock free during the missing-rows diagnostic")
+                .is_some(),
+            "pane vanished"
+        );
+
+        let text = expect_yanked(answered);
+        assert_eq!(text.split('\n').count(), 5, "one line per requested row");
+        drop(gate);
     }
 
     #[tokio::test]

--- a/crates/oakterm-daemon/src/requests/scrollback.rs
+++ b/crates/oakterm-daemon/src/requests/scrollback.rs
@@ -6,8 +6,9 @@ use crate::wire::row_to_wire;
 use oakterm_protocol::frame::Frame;
 use oakterm_protocol::message::{ErrorCode, GetScrollback, MSG_SCROLLBACK_DATA, ScrollbackData};
 use oakterm_protocol::render::DirtyRow;
+use oakterm_terminal::grid::cell::Rgb;
 use oakterm_terminal::grid::row::Row;
-use oakterm_terminal::scroll::archive_manager::ArchiveManager;
+use oakterm_terminal::scroll::archive_manager::{ArchiveManager, ArchiveReader};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{error, warn};
@@ -65,7 +66,7 @@ pub(super) async fn get_scrollback(
             "malformed GetScrollback",
         );
     };
-    let Some(pane) = lock_live_pane(panes, req.pane_id).await else {
+    let Some(snapshot) = snapshot_under_lock(conn_id, &req, panes).await else {
         return make_error_response(
             conn_id,
             frame.serial,
@@ -73,18 +74,39 @@ pub(super) async fn get_scrollback(
             "unknown pane",
         );
     };
-    let base = pane.copy_mode_base(conn_id);
-    let layout = HistoryLayout::of(&pane);
-    let buf = pane.screens.scrollback();
-    let archive = pane.screens.archive();
-    let plan = plan_scrollback_read(&layout, base, req.start_row, req.count);
+    let ScrollbackSnapshot {
+        plan,
+        access,
+        palette,
+        cols,
+        tail,
+    } = snapshot;
 
-    let rows = match build_scrollback_rows(conn_id, req.pane_id, &pane, &plan, archive, buf) {
-        Ok(rows) => rows,
-        Err(message) => {
-            return make_error_response(conn_id, frame.serial, ErrorCode::InternalError, message);
-        }
-    };
+    let mut rows: Vec<DirtyRow> = Vec::with_capacity(plan.archive_count + tail.len());
+    if plan.archive_count > 0 {
+        let found = match read_archive_rows(
+            conn_id,
+            req.pane_id,
+            access,
+            plan.archive_start,
+            plan.archive_count,
+        )
+        .await
+        {
+            Ok(found) => found,
+            Err(message) => {
+                return make_error_response(
+                    conn_id,
+                    frame.serial,
+                    ErrorCode::InternalError,
+                    message,
+                );
+            }
+        };
+        let (aligned, _) = align_archive_rows(found, plan.archive_start, plan.archive_count, cols);
+        rows.extend(aligned.iter().map(|row| row_to_wire(row, 0, &palette)));
+    }
+    rows.extend(tail);
 
     let data = ScrollbackData {
         pane_id: req.pane_id,
@@ -119,33 +141,60 @@ pub(super) async fn get_scrollback(
     }
 }
 
-/// Assemble the response rows in absolute-index order: archived, then
-/// blanks for the pruned-without-an-archive gap, then hot buffer rows.
-fn build_scrollback_rows(
+/// Everything a response needs from behind the pane lock, so the archive
+/// read can run without it. The hot rows are converted here rather than
+/// after that read: a prune while the lock is free would shift them out
+/// from under `plan.hot_start`.
+///
+/// Nothing here is re-read afterwards, so a pane closing mid-read still
+/// yields a consistent response — deliberately unlike `resolve_yank`,
+/// which re-locks to assemble and so fails a closed pane. Refusing would
+/// only lose history the client can no longer obtain.
+struct ScrollbackSnapshot {
+    plan: ScrollbackReadPlan,
+    access: ArchiveAccess,
+    palette: [Rgb; 256],
+    cols: usize,
+    /// Blanks for the pruned-without-an-archive gap, then hot buffer rows
+    /// — everything after the archived portion of the window.
+    tail: Vec<DirtyRow>,
+}
+
+async fn snapshot_under_lock(
+    conn_id: u64,
+    req: &GetScrollback,
+    panes: &Arc<Mutex<PaneManager>>,
+) -> Option<ScrollbackSnapshot> {
+    let pane = lock_live_pane(panes, req.pane_id).await?;
+    let layout = HistoryLayout::of(&pane);
+    let plan = plan_scrollback_read(
+        &layout,
+        pane.copy_mode_base(conn_id),
+        req.start_row,
+        req.count,
+    );
+    let grid = pane.screens.active_grid();
+    let palette = grid.palette;
+    let cols = usize::from(grid.cols);
+    Some(ScrollbackSnapshot {
+        tail: build_tail_rows(conn_id, req.pane_id, &pane, &plan, cols, &palette),
+        access: ArchiveAccess::of(&pane),
+        plan,
+        palette,
+        cols,
+    })
+}
+
+fn build_tail_rows(
     conn_id: u64,
     pane_id: u32,
     pane: &PaneState,
     plan: &ScrollbackReadPlan,
-    archive: Option<&ArchiveManager>,
-    buf: &oakterm_terminal::scroll::HotBuffer,
-) -> Result<Vec<DirtyRow>, &'static str> {
-    let palette = &pane.screens.active_grid().palette;
-    let cols = usize::from(pane.screens.active_grid().cols);
-    let mut rows: Vec<DirtyRow> =
-        Vec::with_capacity(plan.archive_count + plan.gap_count + plan.hot_count);
-
-    if plan.archive_count > 0 {
-        let found = read_archive_rows(
-            conn_id,
-            pane_id,
-            archive,
-            plan.archive_start,
-            plan.archive_count,
-        )?;
-        for row in align_archive_rows(found, plan.archive_start, plan.archive_count, cols) {
-            rows.push(row_to_wire(&row, 0, palette));
-        }
-    }
+    cols: usize,
+    palette: &[Rgb; 256],
+) -> Vec<DirtyRow> {
+    let buf = pane.screens.scrollback();
+    let mut rows: Vec<DirtyRow> = Vec::with_capacity(plan.gap_count + plan.hot_count);
 
     if plan.gap_count > 0 {
         warn!(
@@ -175,37 +224,107 @@ fn build_scrollback_rows(
             rows.push(row_to_wire(&Row::new(cols), 0, palette));
         }
     }
-    Ok(rows)
+    rows
 }
 
-/// Errors surface as an error frame, never blank rows: a blank means a
-/// permanent gap, but a transient failure (wedged writer, EIO) must stay
-/// retryable for the client.
-pub(super) fn read_archive_rows(
+/// Read archived rows off the runtime, holding no pane lock: the query
+/// blocks until the writer answers or its timeout expires, which must
+/// stall neither the pane nor a tokio worker (TREK-197).
+///
+/// Every failure — a dead or wedged writer, a disk error, a panicking
+/// read — surfaces as an error frame, never blank rows: a blank means a
+/// permanent gap, but a transient failure must stay retryable.
+pub(super) async fn read_archive_rows(
     conn_id: u64,
     pane_id: u32,
-    archive: Option<&ArchiveManager>,
+    access: ArchiveAccess,
     start: u64,
     count: usize,
 ) -> Result<Vec<(u64, Row)>, &'static str> {
-    let Some(archive) = archive else {
-        // Unreachable in practice: a nonzero count implies archived > 0,
-        // read from this same binding. Logged loudly in case that
-        // invariant ever breaks.
-        error!(conn_id, pane_id, "archive vanished mid-request");
-        return Err("archive unavailable");
+    let reader = match access {
+        ArchiveAccess::Ready(reader) => reader,
+        ArchiveAccess::WriterGone => {
+            warn!(
+                conn_id,
+                pane_id, start, count, "archive writer shut down; window unreadable"
+            );
+            return Err("archive unavailable");
+        }
+        ArchiveAccess::Absent => {
+            // The plan only asks for archived rows when `archived > 0`,
+            // which a pane without an archive can never reach.
+            error!(
+                conn_id,
+                pane_id, start, count, "archived rows planned on a pane with no archive"
+            );
+            return Err("archive unavailable");
+        }
     };
-    archive.read_range(start, count).map_err(|e| {
-        warn!(
-            conn_id,
-            pane_id,
-            start,
-            count,
-            error = %e,
-            "archive read failed"
-        );
-        "archive read failed"
-    })
+    let outcome = tokio::task::spawn_blocking(move || reader.read_range(start, count)).await;
+    map_read_outcome(conn_id, pane_id, start, count, outcome)
+}
+
+/// How a pane's archive can be reached for a read. The two unreadable
+/// states are kept apart because they mean opposite things: a writer that
+/// shut down is a routine post-teardown read, while a plan that wants
+/// archived rows from a pane holding no archive is a broken invariant.
+#[derive(Clone)]
+pub(super) enum ArchiveAccess {
+    Ready(ArchiveReader),
+    WriterGone,
+    Absent,
+}
+
+impl ArchiveAccess {
+    pub(super) fn of(pane: &PaneState) -> Self {
+        match pane.screens.archive() {
+            None => Self::Absent,
+            Some(archive) => archive.reader().map_or(Self::WriterGone, Self::Ready),
+        }
+    }
+
+    pub(super) fn reader(&self) -> Option<&ArchiveReader> {
+        match self {
+            Self::Ready(reader) => Some(reader),
+            Self::WriterGone | Self::Absent => None,
+        }
+    }
+}
+
+type ReadOutcome = Result<std::io::Result<Vec<(u64, Row)>>, tokio::task::JoinError>;
+
+fn map_read_outcome(
+    conn_id: u64,
+    pane_id: u32,
+    start: u64,
+    count: usize,
+    outcome: ReadOutcome,
+) -> Result<Vec<(u64, Row)>, &'static str> {
+    match outcome {
+        Ok(Ok(rows)) => Ok(rows),
+        Ok(Err(e)) => {
+            warn!(
+                conn_id,
+                pane_id,
+                start,
+                count,
+                error = %e,
+                "archive read failed"
+            );
+            Err("archive read failed")
+        }
+        Err(e) => {
+            error!(
+                conn_id,
+                pane_id,
+                start,
+                count,
+                error = %e,
+                "archive read task failed"
+            );
+            Err("archive read failed")
+        }
+    }
 }
 
 /// How a `GetScrollback` request maps onto the combined history:
@@ -265,15 +384,20 @@ fn plan_scrollback_read(
 /// `[start, start + count)`, blank-filling indices the archive has no
 /// row for (gaps from the Spec-0004 overload policy) so the client can
 /// consume the response by position.
+///
+/// Returns the rows alongside how many the archive actually supplied —
+/// the difference is blank fill, which the client cannot tell from real
+/// blank output, so callers that report on the read need the count.
 pub(super) fn align_archive_rows(
     found: Vec<(u64, Row)>,
     start: u64,
     count: usize,
     cols: usize,
-) -> Vec<Row> {
+) -> (Vec<Row>, usize) {
     let mut found = found.into_iter().peekable();
     let mut out_of_contract: u64 = 0;
-    let rows = (start..start + count as u64)
+    let mut supplied = 0usize;
+    let rows: Vec<Row> = (start..start + count as u64)
         .map(|idx| {
             // Entries behind the cursor (index regression, duplicates)
             // violate the sorted-unique contract; absorbing one silently
@@ -283,7 +407,10 @@ pub(super) fn align_archive_rows(
                 out_of_contract += 1;
             }
             match found.peek() {
-                Some((i, _)) if *i == idx => found.next().expect("peeked").1,
+                Some((i, _)) if *i == idx => {
+                    supplied += 1;
+                    found.next().expect("peeked").1
+                }
                 _ => Row::new(cols),
             }
         })
@@ -295,12 +422,26 @@ pub(super) fn align_archive_rows(
             start, count, "archive rows outside the requested window; indexing bug suspected"
         );
     }
-    rows
+    if supplied < count {
+        // Expected when the archive dropped rows under load, and the only
+        // signal that the blanks below are missing data rather than blank
+        // terminal output.
+        warn!(
+            missing = count - supplied,
+            start, count, "archive supplied fewer rows than the window; blank-filled"
+        );
+    }
+    (rows, supplied)
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use super::*;
+    use oakterm_protocol::message::ErrorMessage;
+    use oakterm_terminal::scroll::archive_manager::ReadStall;
+    use std::time::Duration;
+
+    const COLS: usize = 80;
 
     /// A pane whose whole history is still reachable: everything pruned
     /// out of the hot buffer was captured by the archive.
@@ -448,7 +589,7 @@ mod tests {
 
         let aligned = align_archive_rows(vec![(12, row_a), (14, row_b)], 10, 6, 4);
 
-        let heads: Vec<char> = aligned.iter().map(|r| r.cells[0].codepoint).collect();
+        let heads: Vec<char> = aligned.0.iter().map(|r| r.cells[0].codepoint).collect();
         assert_eq!(heads, vec!['\0', '\0', 'A', '\0', 'B', '\0']);
     }
 
@@ -462,7 +603,7 @@ mod tests {
         // An entry below the window must not wedge alignment of later rows.
         let aligned = align_archive_rows(vec![(9, stale), (12, row_a)], 10, 4, 4);
 
-        let heads: Vec<char> = aligned.iter().map(|r| r.cells[0].codepoint).collect();
+        let heads: Vec<char> = aligned.0.iter().map(|r| r.cells[0].codepoint).collect();
         assert_eq!(heads, vec!['\0', '\0', 'A', '\0']);
     }
 
@@ -472,6 +613,350 @@ mod tests {
         assert_eq!(
             plan.archive_count + plan.hot_count,
             MAX_SCROLLBACK_ROWS_PER_REQUEST as usize
+        );
+    }
+
+    // --- Handler ---
+
+    fn row_from(text: &str) -> Row {
+        let mut row = Row::new(COLS);
+        for (cell, ch) in row.cells.iter_mut().zip(text.chars()) {
+            cell.codepoint = ch;
+        }
+        row
+    }
+
+    fn scrollback_frame(pane_id: u32, start_row: i64, count: u32) -> Frame {
+        Frame::new(
+            oakterm_protocol::message::MSG_GET_SCROLLBACK,
+            9,
+            GetScrollback {
+                pane_id,
+                start_row,
+                count,
+            }
+            .encode(),
+        )
+        .expect("frame")
+    }
+
+    /// Drives the real prune-into-archive path: only rows that pass
+    /// through the hot buffer are counted in the absolute index space.
+    async fn pane_with_archived_prefix(
+        dir: &std::path::Path,
+        lines: &[&str],
+        keep: usize,
+    ) -> (Arc<Mutex<PaneManager>>, u32) {
+        let panes = Arc::new(Mutex::new(PaneManager::new()));
+        let pane_id = panes
+            .lock()
+            .await
+            .create(80, 24, String::new(), String::new());
+        {
+            let mut pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            let archive =
+                ArchiveManager::new(dir.join("archive"), 1 << 20).expect("create archive");
+            pane.screens.set_archive(archive);
+
+            pane.screens.push_to_scrollback(row_from(lines[0]));
+            let row_bytes = pane.screens.scrollback().used_bytes();
+            let pruned = pane
+                .screens
+                .scrollback_mut()
+                .set_max_bytes(row_bytes * (keep + 1));
+            assert!(pruned.is_empty(), "resize must not drop rows unarchived");
+            for line in &lines[1..] {
+                pane.screens.push_to_scrollback(row_from(line));
+            }
+        }
+        (panes, pane_id)
+    }
+
+    fn response_rows(result: RequestResult) -> Vec<String> {
+        let RequestResult::Response(frame) = result else {
+            panic!("expected a ScrollbackData response");
+        };
+        assert_eq!(frame.msg_type, MSG_SCROLLBACK_DATA);
+        ScrollbackData::decode(&frame.payload)
+            .expect("decode ScrollbackData")
+            .rows
+            .iter()
+            .map(|row| {
+                row.cells
+                    .iter()
+                    .map(|c| char::from_u32(c.codepoint).unwrap_or('\0'))
+                    .collect::<String>()
+                    .trim_end_matches('\0')
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn get_scrollback_spans_the_archive_boundary() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+
+        let result = get_scrollback(1, &scrollback_frame(pane_id, -4, 4), &panes).await;
+
+        assert_eq!(response_rows(result), vec!["one", "two", "three", "four"]);
+    }
+
+    /// The genuine disk-failure path: the writer is alive and answers,
+    /// but the read itself fails. Distinct from the shut-down case below,
+    /// which is refused before any read is attempted — both produce an
+    /// error frame, so only a test that actually reaches `read_range` can
+    /// tell the arms apart.
+    #[tokio::test]
+    async fn get_scrollback_reports_a_failing_disk_read() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive_dir = dir.path().join("archive");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        {
+            let mut pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            let archive = pane.screens.archive_mut().expect("archive");
+            archive.flush_pending().expect("flush");
+            archive.seal_active_segment().expect("seal");
+        }
+        // The writer keeps its segment metadata, so the read is attempted
+        // and fails on the missing file rather than being skipped.
+        let mut removed = 0;
+        for entry in std::fs::read_dir(&archive_dir).expect("read archive dir") {
+            let entry = entry.expect("dir entry");
+            if entry.file_name().to_string_lossy().starts_with("segment-") {
+                std::fs::remove_file(entry.path()).expect("remove segment");
+                removed += 1;
+            }
+        }
+        assert!(removed > 0, "need a sealed segment to break");
+
+        let RequestResult::Response(frame) =
+            get_scrollback(1, &scrollback_frame(pane_id, -4, 4), &panes).await
+        else {
+            panic!("expected an error response");
+        };
+        let err = ErrorMessage::decode(&frame.payload).expect("decode ErrorMessage");
+        assert_eq!(
+            ErrorCode::try_from(err.code).expect("known code"),
+            ErrorCode::InternalError
+        );
+    }
+
+    /// A transient archive failure must surface as an error frame, never
+    /// as blank rows — a blank means a permanent hole, but a dead or
+    /// wedged writer is retryable.
+    #[tokio::test]
+    async fn get_scrollback_reports_an_archive_read_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        {
+            let mut pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens
+                .archive_mut()
+                .expect("archive")
+                .shutdown()
+                .expect("shutdown");
+        }
+
+        let RequestResult::Response(frame) =
+            get_scrollback(1, &scrollback_frame(pane_id, -4, 4), &panes).await
+        else {
+            panic!("expected an error response");
+        };
+        let err = ErrorMessage::decode(&frame.payload).expect("decode ErrorMessage");
+        assert_eq!(
+            ErrorCode::try_from(err.code).expect("known code"),
+            ErrorCode::InternalError
+        );
+    }
+
+    /// Wait until a read has actually reached the archive writer. A fixed
+    /// sleep would only distinguish "finished" from "not finished": a task
+    /// that had not yet reached the read would leave the pane lock free
+    /// for the innocent reason that nobody had taken it, and every lock
+    /// assertion below it would pass vacuously.
+    pub(in crate::requests) async fn await_read_in_flight(stall: &mut ReadStall) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !stall.read_arrived() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "no archive read reached the writer"
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    /// The contract has two halves, and this is the half a `worker_threads
+    /// = 4` test cannot see: the read must be on `spawn_blocking`, not on
+    /// a runtime worker. With a single worker, a read left inline occupies
+    /// the only thread the runtime has and all async work stops — the
+    /// starvation this whole task exists to prevent.
+    ///
+    /// Driven from a plain thread rather than `#[tokio::test]` because
+    /// every observation has to happen from outside the runtime: a starved
+    /// worker cannot run the assertions that would notice it starving, so
+    /// an in-runtime check only sees the aftermath and blames whatever it
+    /// trips over next.
+    #[test]
+    fn a_stalled_archive_read_does_not_occupy_a_runtime_worker() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) = rt.block_on(pane_with_archived_prefix(
+            dir.path(),
+            &["one", "two", "three", "four"],
+            2,
+        ));
+        let mut stall = rt.block_on(async {
+            let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens.archive().expect("archive").stall_next_read()
+        });
+
+        // A canary that can only tick if the runtime still has a worker.
+        let ticks = Arc::new(AtomicU64::new(0));
+        rt.spawn({
+            let ticks = Arc::clone(&ticks);
+            async move {
+                loop {
+                    ticks.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
+            }
+        });
+        let request = rt.spawn({
+            let panes = Arc::clone(&panes);
+            let frame = scrollback_frame(pane_id, -4, 4);
+            async move { get_scrollback(1, &frame, &panes).await }
+        });
+
+        while !stall.read_arrived() {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let before = ticks.load(Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(200));
+        let after = ticks.load(Ordering::SeqCst);
+        assert!(
+            after > before,
+            "runtime worker starved by the archive read: the canary made no progress \
+             in 200ms while the read was parked"
+        );
+
+        stall.release();
+        assert_eq!(
+            response_rows(rt.block_on(request).expect("request task")),
+            vec!["one", "two", "three", "four"]
+        );
+    }
+
+    /// The proof that the archive read no longer runs under the pane
+    /// lock: with the writer parked, the request cannot answer, yet the
+    /// pane stays lockable. The budget is far under the archive's 10s
+    /// query timeout, so the lock-held shape fails here instead of
+    /// hanging.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_stalled_archive_read_does_not_hold_the_pane_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        let mut stall = {
+            let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens.archive().expect("archive").stall_next_read()
+        };
+
+        let request = tokio::spawn({
+            let panes = Arc::clone(&panes);
+            let frame = scrollback_frame(pane_id, -4, 4);
+            async move { get_scrollback(1, &frame, &panes).await }
+        });
+        await_read_in_flight(&mut stall).await;
+
+        assert!(
+            !request.is_finished(),
+            "the stalled writer must still be blocking the read"
+        );
+        let locked =
+            tokio::time::timeout(Duration::from_millis(500), lock_live_pane(&panes, pane_id)).await;
+        assert!(
+            locked
+                .expect("pane lock free during the archive read")
+                .is_some(),
+            "pane vanished"
+        );
+
+        stall.release();
+        let rows = response_rows(request.await.expect("request task"));
+        assert_eq!(rows, vec!["one", "two", "three", "four"]);
+    }
+
+    /// Why this handler needs no top-up, unlike a yank: the hot rows are
+    /// converted while the lock is held, so rows migrating into the
+    /// archive during the read can be neither served twice nor lost.
+    /// Rebuilding the tail afterwards would read a hot buffer that had
+    /// moved on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn rows_migrating_into_the_archive_mid_read_are_served_exactly_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (panes, pane_id) =
+            pane_with_archived_prefix(dir.path(), &["one", "two", "three", "four"], 2).await;
+        let mut stall = {
+            let pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            pane.screens.archive().expect("archive").stall_next_read()
+        };
+
+        let request = tokio::spawn({
+            let panes = Arc::clone(&panes);
+            let frame = scrollback_frame(pane_id, -4, 4);
+            async move { get_scrollback(1, &frame, &panes).await }
+        });
+        await_read_in_flight(&mut stall).await;
+
+        // "three" and "four" migrate out of the hot buffer and into the
+        // archive while the snapshot's archive read is still parked.
+        {
+            let mut pane = lock_live_pane(&panes, pane_id).await.expect("pane");
+            for line in ["five", "six"] {
+                pane.screens.push_to_scrollback(row_from(line));
+            }
+            assert!(
+                pane.screens
+                    .archive()
+                    .expect("archive")
+                    .total_rows_received()
+                    > 2,
+                "the pushes must archive rows the request already snapshotted"
+            );
+        }
+
+        stall.release();
+        assert_eq!(
+            response_rows(request.await.expect("request task")),
+            vec!["one", "two", "three", "four"]
+        );
+    }
+
+    /// Covers the mapping only: a `JoinError` — which a panicking blocking
+    /// task produces — must become an error rather than a silent empty
+    /// result the client would read as a permanent gap. The production
+    /// wiring around it is not exercised here; nothing in `read_range`
+    /// panics on purpose, so a real one cannot be provoked without a hook
+    /// that would only test itself.
+    #[tokio::test]
+    async fn a_join_error_maps_to_an_error_not_an_empty_read() {
+        let join_error = tokio::spawn(async { panic!("boom") })
+            .await
+            .expect_err("task panicked");
+
+        assert_eq!(
+            map_read_outcome(1, 2, 0, 4, Err(join_error)),
+            Err("archive read failed")
         );
     }
 

--- a/crates/oakterm-terminal/Cargo.toml
+++ b/crates/oakterm-terminal/Cargo.toml
@@ -7,6 +7,11 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Writer-thread stall hook, for tests in downstream crates that need a
+# deterministically unresponsive archive. Never enable in a release build.
+test-hooks = []
+
 [dependencies]
 oakterm-common = { path = "../oakterm-common" }
 postcard.workspace = true

--- a/crates/oakterm-terminal/src/scroll/archive_manager.rs
+++ b/crates/oakterm-terminal/src/scroll/archive_manager.rs
@@ -13,6 +13,7 @@ use crate::scroll::archive_core::{ArchiveCore, ArchiveStats};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, SyncSender};
+use std::sync::{Arc, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -25,6 +26,11 @@ const MAILBOX_DEPTH: usize = 4;
 /// can't respond within this is treated as wedged; callers get an error
 /// (or a best-effort default) instead of hanging.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long teardown waits for a writer to notice the disconnect. Short
+/// on purpose: the wait only covers a message already being processed,
+/// and a writer that needs longer is abandoned rather than held onto.
+const JOIN_GRACE: Duration = Duration::from_secs(1);
 
 /// Message to the writer thread. Queries carry a reply channel; the
 /// writer answers after processing everything queued before them.
@@ -50,8 +56,16 @@ enum WriterMsg {
     /// Block the writer until `gate`'s sender drops — deterministic
     /// saturation for tests. `entered` acks that the writer is parked,
     /// so callers know later batches can't be drained early.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-hooks"))]
     Stall {
+        entered: SyncSender<()>,
+        gate: mpsc::Receiver<()>,
+    },
+    /// Arm a one-shot stall on the *next* read. Unlike `Stall`, this
+    /// signals only once a read has actually arrived, giving tests a
+    /// rendezvous on the read being in flight rather than a sleep.
+    #[cfg(any(test, feature = "test-hooks"))]
+    StallNextRead {
         entered: SyncSender<()>,
         gate: mpsc::Receiver<()>,
     },
@@ -78,8 +92,11 @@ pub struct ArchiveManager {
 }
 
 /// Channel and thread of a running writer; both live and die together.
+/// This is the only strong reference to the sender, so dropping it
+/// disconnects the mailbox — that disconnect is the writer's exit signal,
+/// and it is why [`ArchiveReader`] may only ever hold a `Weak`.
 struct WriterHandle {
-    tx: SyncSender<WriterMsg>,
+    tx: Arc<SyncSender<WriterMsg>>,
     thread: thread::JoinHandle<()>,
 }
 
@@ -89,6 +106,137 @@ struct WriterHandle {
 fn log_if_unheard<T>(send_result: Result<(), mpsc::SendError<io::Result<T>>>, op: &str) {
     if let Err(mpsc::SendError(Err(e))) = send_result {
         tracing::warn!(error = %e, op, "archive operation failed after caller stopped waiting");
+    }
+}
+
+/// Enqueue `msg`, retrying while the mailbox is full of batches, giving up
+/// at `deadline`.
+///
+/// The strong reference is taken per attempt and released before the
+/// sleep. Holding it across the wait would keep the mailbox connected
+/// while nothing is draining it, which is exactly how a caller here could
+/// stall a teardown running on another thread.
+fn send_with_deadline(
+    tx: &Weak<SyncSender<WriterMsg>>,
+    mut msg: WriterMsg,
+    deadline: Instant,
+) -> io::Result<()> {
+    loop {
+        let Some(sender) = tx.upgrade() else {
+            return Err(io::Error::other("archive writer thread exited"));
+        };
+        match sender.try_send(msg) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::TrySendError::Full(returned)) => {
+                if Instant::now() >= deadline {
+                    return Err(io::Error::other(
+                        "archive writer did not accept a query within 10s",
+                    ));
+                }
+                msg = returned;
+                drop(sender);
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                return Err(io::Error::other("archive writer thread exited"));
+            }
+        }
+    }
+}
+
+/// Enqueue a query with a bounded wait on both the send and the reply.
+/// Every caller — manager and reader alike — goes through this, so the
+/// wedged-writer contract has one definition.
+///
+/// The reply rides its own channel, so no reference to the mailbox is held
+/// while waiting for it: a teardown may disconnect the writer mid-query,
+/// and this call then ends on the reply channel closing.
+fn query_writer<T>(
+    tx: &Weak<SyncSender<WriterMsg>>,
+    build: impl FnOnce(SyncSender<T>) -> WriterMsg,
+) -> io::Result<T> {
+    let deadline = Instant::now() + QUERY_TIMEOUT;
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    send_with_deadline(tx, build(reply_tx), deadline)?;
+    match reply_rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+        Ok(value) => Ok(value),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(io::Error::other("archive writer thread exited"))
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            Err(io::Error::other("archive writer did not reply within 10s"))
+        }
+    }
+}
+
+/// Read-only handle to a pane's archive writer.
+///
+/// `Send + 'static` and cloneable, so a read can be moved onto a blocking
+/// task rather than run under whatever locks the caller holds. Reads
+/// observe the same state the owning [`ArchiveManager`] would: the writer
+/// answers them in mailbox order.
+///
+/// The reference is deliberately weak: teardown stops the writer by
+/// dropping the manager's sender, so a reader that could hold it alive
+/// would leak the thread. Methods fail fast once the manager is gone.
+#[derive(Clone)]
+pub struct ArchiveReader {
+    tx: Weak<SyncSender<WriterMsg>>,
+}
+
+impl ArchiveReader {
+    /// Read archived rows in `[start, start + count)`, tagged with their
+    /// absolute indices — see [`ArchiveManager::read_range`] for the
+    /// gap and alignment contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading from disk fails or the writer is dead
+    /// or wedged.
+    pub fn read_range(&self, start: u64, count: usize) -> io::Result<Vec<(u64, Row)>> {
+        query_writer(&self.tx, |reply| WriterMsg::Read {
+            start,
+            count,
+            reply,
+        })?
+    }
+
+    /// Rows the writer itself lost: paused discards and write-error
+    /// abandonment. Add [`ArchiveManager::dropped_rows`] for the total —
+    /// enqueue-side drops are counted on the caller's thread, not here.
+    /// A mailbox round-trip like any query; `None` whenever that query
+    /// fails — writer gone, wedged, or unreachable.
+    #[must_use]
+    pub fn writer_lost_rows(&self) -> Option<u64> {
+        query_writer(&self.tx, WriterMsg::Stats)
+            .inspect_err(|e| tracing::debug!(error = %e, "archive stats query failed"))
+            .ok()
+            .map(|s| s.lost_rows)
+    }
+}
+
+/// A read parked at the writer, from [`ArchiveManager::stall_next_read`].
+/// Polling is non-blocking so async tests can await on it without tying
+/// up a runtime worker.
+#[cfg(any(test, feature = "test-hooks"))]
+pub struct ReadStall {
+    entered: mpsc::Receiver<()>,
+    gate: SyncSender<()>,
+    arrived: bool,
+}
+
+#[cfg(any(test, feature = "test-hooks"))]
+impl ReadStall {
+    /// Whether a read has reached the writer and parked. Latches, so it
+    /// stays true once observed.
+    pub fn read_arrived(&mut self) -> bool {
+        self.arrived |= self.entered.try_recv().is_ok();
+        self.arrived
+    }
+
+    /// Let the parked read proceed.
+    pub fn release(self) {
+        drop(self.gate);
     }
 }
 
@@ -105,6 +253,8 @@ impl ArchiveManager {
     pub fn new(session_dir: PathBuf, max_disk_bytes: u64) -> io::Result<Self> {
         let mut core = ArchiveCore::new(session_dir.clone(), max_disk_bytes)?;
         let (tx, rx) = mpsc::sync_channel::<WriterMsg>(MAILBOX_DEPTH);
+        #[cfg(any(test, feature = "test-hooks"))]
+        let mut stall_next_read: Option<(SyncSender<()>, mpsc::Receiver<()>)> = None;
         let writer_thread = thread::Builder::new()
             .name("archive-writer".to_string())
             .spawn(move || {
@@ -129,6 +279,11 @@ impl ArchiveManager {
                             count,
                             reply,
                         } => {
+                            #[cfg(any(test, feature = "test-hooks"))]
+                            if let Some((entered, gate)) = stall_next_read.take() {
+                                let _ = entered.send(());
+                                let _ = gate.recv();
+                            }
                             // Seal only when the window reaches unsealed
                             // rows, so reads of pure history don't churn
                             // segments or risk read-triggered loss on a
@@ -153,10 +308,14 @@ impl ArchiveManager {
                             log_if_unheard(reply.send(core.shutdown()), "shutdown");
                             break;
                         }
-                        #[cfg(test)]
+                        #[cfg(any(test, feature = "test-hooks"))]
                         WriterMsg::Stall { entered, gate } => {
                             let _ = entered.send(());
                             let _ = gate.recv();
+                        }
+                        #[cfg(any(test, feature = "test-hooks"))]
+                        WriterMsg::StallNextRead { entered, gate } => {
+                            stall_next_read = Some((entered, gate));
                         }
                         #[cfg(test)]
                         #[allow(clippy::missing_panics_doc)]
@@ -166,7 +325,7 @@ impl ArchiveManager {
             })?;
         Ok(Self {
             writer: Some(WriterHandle {
-                tx,
+                tx: Arc::new(tx),
                 thread: writer_thread,
             }),
             session_dir,
@@ -228,42 +387,80 @@ impl ArchiveManager {
         }
     }
 
-    /// Enqueue a query with a bounded wait on both the send (the mailbox
-    /// may be full of batches) and the reply.
     fn query<T>(&self, build: impl FnOnce(SyncSender<T>) -> WriterMsg) -> io::Result<T> {
         let writer = self
             .writer
             .as_ref()
             .ok_or_else(|| io::Error::other("archive writer shut down"))?;
-        let deadline = Instant::now() + QUERY_TIMEOUT;
-        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
-        let mut msg = build(reply_tx);
-        loop {
-            match writer.tx.try_send(msg) {
-                Ok(()) => break,
-                Err(mpsc::TrySendError::Full(returned)) => {
-                    if Instant::now() >= deadline {
-                        return Err(io::Error::other(
-                            "archive writer did not accept a query within 10s",
-                        ));
-                    }
-                    msg = returned;
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Err(mpsc::TrySendError::Disconnected(_)) => {
-                    return Err(io::Error::other("archive writer thread exited"));
-                }
-            }
+        // Borrowing `self` keeps the strong reference alive for the call,
+        // so the downgrade here can always be upgraded back.
+        query_writer(&Arc::downgrade(&writer.tx), build)
+    }
+
+    /// A handle that can read this archive without borrowing the manager,
+    /// so callers can hand the read to another thread instead of holding
+    /// their own locks across it. `None` once the writer is shut down.
+    #[must_use]
+    pub fn reader(&self) -> Option<ArchiveReader> {
+        self.writer.as_ref().map(|w| ArchiveReader {
+            tx: Arc::downgrade(&w.tx),
+        })
+    }
+
+    /// Park the writer on the *next* read it receives, so tests can wait
+    /// for a read to be genuinely in flight instead of sleeping and
+    /// assuming. Unlike [`Self::stall_writer`], the signal proves the read
+    /// reached the writer, which also orders anything enqueued afterwards
+    /// behind it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the writer is already gone.
+    #[cfg(any(test, feature = "test-hooks"))]
+    #[must_use]
+    pub fn stall_next_read(&self) -> ReadStall {
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let (gate_tx, gate_rx) = mpsc::sync_channel(0);
+        self.writer
+            .as_ref()
+            .expect("writer running")
+            .tx
+            .send(WriterMsg::StallNextRead {
+                entered: entered_tx,
+                gate: gate_rx,
+            })
+            .expect("send stall-next-read");
+        ReadStall {
+            entered: entered_rx,
+            gate: gate_tx,
+            arrived: false,
         }
-        match reply_rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
-            Ok(value) => Ok(value),
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                Err(io::Error::other("archive writer thread exited"))
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                Err(io::Error::other("archive writer did not reply within 10s"))
-            }
-        }
+    }
+
+    /// Park the writer until the returned sender drops, so tests can
+    /// exercise callers against a writer that will not answer. Returns
+    /// once the writer is actually parked — without that rendezvous it
+    /// could still drain queued work first.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the writer is already gone.
+    #[cfg(any(test, feature = "test-hooks"))]
+    #[must_use]
+    pub fn stall_writer(&self) -> SyncSender<()> {
+        let (entered_tx, entered_rx) = mpsc::sync_channel(0);
+        let (gate_tx, gate_rx) = mpsc::sync_channel(0);
+        self.writer
+            .as_ref()
+            .expect("writer running")
+            .tx
+            .send(WriterMsg::Stall {
+                entered: entered_tx,
+                gate: gate_rx,
+            })
+            .expect("send stall");
+        entered_rx.recv().expect("writer parked in stall");
+        gate_tx
     }
 
     /// Observable state snapshot; `None` when the writer is dead or wedged.
@@ -304,11 +501,9 @@ impl ArchiveManager {
     /// Returns an error if reading from disk fails or the writer is dead
     /// or wedged.
     pub fn read_range(&self, start: u64, count: usize) -> io::Result<Vec<(u64, Row)>> {
-        self.query(|reply| WriterMsg::Read {
-            start,
-            count,
-            reply,
-        })?
+        self.reader()
+            .ok_or_else(|| io::Error::other("archive writer shut down"))?
+            .read_range(start, count)
     }
 
     /// Every row ever handed to `archive_rows`, whether stored, dropped,
@@ -424,27 +619,44 @@ impl ArchiveManager {
         self.writer.as_ref().is_some_and(|w| w.thread.is_finished())
     }
 
-    /// Join a writer that is known to have exited (or is about to).
-    fn join_writer(&mut self) {
-        if let Some(writer) = self.writer.take() {
-            drop(writer.tx);
-            if writer.thread.join().is_err() {
-                tracing::error!("archive writer thread panicked");
+    /// Disconnect the mailbox and wait up to `grace` for the writer to
+    /// notice and exit.
+    ///
+    /// A writer parked inside a blocking `write` or fsync sees neither the
+    /// disconnect nor anything else until that syscall returns, so the
+    /// wait is bounded and gives up rather than blocking teardown. An
+    /// abandoned thread still exits on its own once it reaches `recv`;
+    /// only the join is lost.
+    fn stop_writer(&mut self, grace: Duration) {
+        let Some(writer) = self.writer.take() else {
+            return;
+        };
+        drop(writer.tx);
+        let deadline = Instant::now() + grace;
+        while !writer.thread.is_finished() {
+            if Instant::now() >= deadline {
+                tracing::warn!(
+                    path = %self.session_dir.display(),
+                    "archive writer did not exit; abandoning it, files left for orphan cleanup"
+                );
+                return;
             }
+            thread::sleep(Duration::from_millis(1));
+        }
+        if writer.thread.join().is_err() {
+            tracing::error!("archive writer thread panicked");
         }
     }
 
-    /// Abandon a wedged writer without joining — joining would hang
-    /// teardown in exactly the scenario the query timeout exists to
-    /// survive; dropping the channel lets it exit on its own.
+    /// Stop a writer expected to be responsive or already gone.
+    fn join_writer(&mut self) {
+        self.stop_writer(JOIN_GRACE);
+    }
+
+    /// Abandon a writer already known to be wedged. Waiting is pointless
+    /// in exactly the scenario the query timeout exists to survive.
     fn detach_writer(&mut self) {
-        if let Some(writer) = self.writer.take() {
-            drop(writer.tx);
-            tracing::warn!(
-                path = %self.session_dir.display(),
-                "detaching wedged archive writer; queued rows may still be written, files left for orphan cleanup"
-            );
-        }
+        self.stop_writer(Duration::ZERO);
     }
 
     /// Delete orphaned archive directories that don't match the current session.
@@ -542,26 +754,6 @@ mod tests {
             .collect()
     }
 
-    /// Block the writer until the returned sender drops, so the mailbox
-    /// can be filled deterministically. Waits for the writer to actually
-    /// park — without the rendezvous it could drain early batches before
-    /// stalling, splitting the drops mid-sequence.
-    fn stall(mgr: &ArchiveManager) -> SyncSender<()> {
-        let (entered_tx, entered_rx) = mpsc::sync_channel(0);
-        let (gate_tx, gate_rx) = mpsc::sync_channel(0);
-        mgr.writer
-            .as_ref()
-            .expect("writer running")
-            .tx
-            .send(WriterMsg::Stall {
-                entered: entered_tx,
-                gate: gate_rx,
-            })
-            .expect("send stall");
-        entered_rx.recv().expect("writer parked in stall");
-        gate_tx
-    }
-
     #[test]
     fn large_batch_triggers_flush() {
         let dir = tempfile::tempdir().unwrap();
@@ -587,7 +779,7 @@ mod tests {
         let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
         let sent = 10 * STALL_BATCHES as u64;
         {
-            let _gate = stall(&mgr);
+            let _gate = mgr.stall_writer();
             for _ in 0..STALL_BATCHES {
                 mgr.archive_rows(make_rows(10, 80)).unwrap();
             }
@@ -609,7 +801,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
         {
-            let _gate = stall(&mgr);
+            let _gate = mgr.stall_writer();
             for _ in 0..=STALL_BATCHES {
                 mgr.archive_rows(make_rows(10, 80)).unwrap();
             }
@@ -684,7 +876,7 @@ mod tests {
         let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
         let sent = 10 * STALL_BATCHES as u64;
         {
-            let _gate = stall(&mgr);
+            let _gate = mgr.stall_writer();
             for _ in 0..STALL_BATCHES {
                 mgr.archive_rows(make_rows(10, 80)).unwrap();
             }
@@ -797,7 +989,7 @@ mod tests {
         let archive_dir = dir.path().join("archive");
         let mut mgr = ArchiveManager::new(archive_dir.clone(), u64::MAX).unwrap();
         {
-            let _gate = stall(&mgr);
+            let _gate = mgr.stall_writer();
             for _ in 0..MAILBOX_DEPTH {
                 mgr.archive_rows(make_rows(10, 80)).unwrap();
             }
@@ -890,6 +1082,138 @@ mod tests {
 
         // Unrecognised name should be left alone.
         assert!(base.join("not-a-pid").exists());
+    }
+
+    #[test]
+    fn reader_sees_rows_the_manager_archived() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
+        mgr.archive_rows(make_rows(10, 40)).unwrap();
+        let reader = mgr.reader().expect("writer running");
+
+        // Same seal-before-read behaviour as the manager's own read.
+        let rows = reader.read_range(0, 10).unwrap();
+        assert_eq!(rows.len(), 10);
+        assert_eq!(rows[9].0, 9);
+        assert_eq!(rows[9].1.cells[0].codepoint, 'J');
+    }
+
+    #[test]
+    fn reader_is_none_after_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
+        mgr.shutdown().unwrap();
+        assert!(mgr.reader().is_none());
+    }
+
+    fn wait_for(within: Duration, mut cond: impl FnMut() -> bool) -> bool {
+        let deadline = Instant::now() + within;
+        while !cond() {
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        true
+    }
+
+    /// The invariant the whole reader design rests on: dropping the
+    /// manager's sender must disconnect the mailbox even with readers
+    /// outstanding, because that disconnect is the writer's only exit
+    /// signal. A reader holding a strong sender would park the thread
+    /// forever.
+    #[test]
+    fn a_reader_cannot_keep_the_writer_thread_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
+        let reader = mgr.reader().expect("writer running");
+        let writer = mgr.writer.take().expect("writer running");
+
+        drop(writer.tx);
+
+        assert!(
+            wait_for(Duration::from_secs(5), || writer.thread.is_finished()),
+            "a reader must not keep the writer thread alive"
+        );
+        writer.thread.join().expect("writer exited cleanly");
+        assert!(reader.read_range(0, 1).is_err());
+    }
+
+    /// Detaching is for a writer already known to be wedged, so it must
+    /// not wait — and with the mailbox full there is no way to ask the
+    /// thread to stop, which is exactly why the exit signal has to be the
+    /// disconnect rather than a message. An outstanding reader must not
+    /// be able to undo it.
+    #[test]
+    fn detaching_a_wedged_writer_neither_waits_nor_leaves_a_way_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
+        let reader = mgr.reader().expect("writer running");
+        let gate = mgr.stall_writer();
+        for _ in 0..STALL_BATCHES {
+            mgr.archive_rows(make_rows(10, 80)).unwrap();
+        }
+
+        let started = Instant::now();
+        mgr.detach_writer();
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "detaching a wedged writer must not wait on it"
+        );
+
+        let started = Instant::now();
+        let err = reader.read_range(0, 1).expect_err("writer unreachable");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a reader whose manager is gone must fail fast, not wait out the query timeout"
+        );
+        assert!(
+            err.to_string().contains("exited"),
+            "unexpected error: {err}"
+        );
+
+        drop(gate);
+    }
+
+    /// A reader handed to a blocking task can outlive the pane it came
+    /// from, and teardown must still finish.
+    #[test]
+    fn an_outstanding_reader_does_not_block_teardown() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = ArchiveManager::new(dir.path().join("archive"), u64::MAX).unwrap();
+        mgr.archive_rows(make_rows(10, 40)).unwrap();
+        let reader = mgr.reader().expect("writer running");
+
+        // Dropped on its own thread so a teardown that blocks fails here
+        // with a diagnosis, rather than hanging until a CI timeout kills
+        // the run and says nothing about which test wedged.
+        let dropped = thread::spawn(move || drop(mgr));
+        assert!(
+            wait_for(Duration::from_secs(10), || dropped.is_finished()),
+            "teardown blocked with a reader outstanding"
+        );
+        dropped.join().expect("teardown panicked");
+
+        // The writer is gone; the stale handle errors instead of hanging.
+        let err = reader.read_range(0, 10).expect_err("writer stopped");
+        assert!(
+            err.to_string().contains("exited"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn an_outstanding_reader_does_not_block_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_dir = dir.path().join("archive");
+        let mut mgr = ArchiveManager::new(archive_dir.clone(), u64::MAX).unwrap();
+        mgr.archive_rows(make_rows(10, 40)).unwrap();
+        let reader = mgr.reader().expect("writer running");
+
+        mgr.shutdown().unwrap();
+
+        assert!(!archive_dir.exists());
+        assert!(reader.read_range(0, 10).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements TREK-197. A wedged archive writer could freeze a pane's PTY read loop for up to 10s and occupy a tokio worker, because `ArchiveManager::read_range` — a blocking mailbox round-trip with a 10s timeout — ran while holding the per-pane lock.

`ArchiveManager` now hands out a cloneable `ArchiveReader`; `GetScrollback` and the copy-mode yank clone it under the lock, **drop the guard**, and run the read via `spawn_blocking`. Neither the pane lock nor a runtime worker is held across the read.

Beyond the read path:

- **Teardown**: `ArchiveReader` holds a `Weak` to the writer mailbox, so channel disconnect remains the writer's sole exit signal. A strong handle would have made `Drop` hang forever once readers outlived the manager — verified by reverting it (teardown ran past 120s). `stop_writer` abandons rather than joins past its grace, since a writer wedged inside `write()`/fsync observes no signal at all.
- **Exactly-once rows**: `GetScrollback` converts the hot tail under the same guard that plans the read, so a row migrating hot→archive mid-read is neither duplicated nor lost. Reverting that ordering yields `["one","two","five","six"]` in place of `["one","two","three","four"]`.
- **Yank top-up** (closes CMT-226): migrated rows are read instead of blank-filled, with the rebase arithmetic extracted into `ArchiveWindow` — its failure mode is wrong text returned as success, so it is now deterministically unit-tested rather than reasoned about.
- **Chunking removed**: `ArchiveCore::read_range` pulls every touched segment file whole, so a chunk loop re-read segments and bounded neither latency nor memory.
- **Diagnostics**: the `lost_rows` round-trip left the pane lock (it was dead logic — `lost_rows` already includes `dropped_rows`), a routine post-shutdown read no longer logs an invariant break, short reads and top-up shortfalls are now visible, and blank-fill causes are bucketed.

## Review

Codex + code-review + silent-failure + test-coverage fan-out, two fix rounds, then a focused re-review (Codex clean; six low/medium items, five fixed here). The teardown redesign came from review — my proposed polled stop flag was replaced by the reviewer's `Weak` handle, which deletes the failure modes instead of guarding them.

Test review caught that deleting `spawn_blocking` entirely still passed every test; the starvation guard added for it must observe from outside the runtime, because a starved worker cannot run its own assertion or service its timer.

Follow-ups filed: TREK-293 (teardown blocking on Drop/shutdown), TREK-294 (DispatchPermit window), TREK-295 (unbounded diagnostic tasks).

## Test plan

- `mise run check` clean (clippy `-D warnings`)
- `mise run test`: 1404 passed / 0 failed (1385 → 1404), stable across repeated runs
- Every bug fix verified non-vacuously by reverting it and confirming the intended failure: strong-Arc handle (teardown hang, 10.01s reader timeout), tail-after-read (row corruption), `spawn_blocking` deletion (worker starvation), rebase deletion (contiguity assert), lock-held probes (both stall tests)

TREK-197