### PR TITLE
docs(ideas): record daily-driver reshuffle in roadmap status

### DIFF
--- a/docs/ideas/33-roadmap.md
+++ b/docs/ideas/33-roadmap.md
@@ -10,7 +10,7 @@ tags: ['roadmap', 'mvp', 'phases', 'priorities']
 
 What gets built first and why.
 
-**Status (2026-07-01):** Phase 0 complete. Phase 1 (multiplexer) in progress.
+**Status (2026-08-17):** Phase 0 complete, bar two deliverables its list still owes — bundled themes and wide-char width handling — both folded into EPIC-13. Phase 1 (multiplexer) in progress: tabs, splits, and the copy-mode core are shipped. After copy mode (EPIC-10), a credible-daily-driver hardening push (EPIC-13: emulation correctness, bundled themes, GUI↔daemon reconnect, install path) runs ahead of the remaining chrome and session-persistence epics, picking up the [distribution](37-distribution.md) work the phase lists never scheduled.
 
 ## Guiding Principle
 


### PR DESCRIPTION
## Summary

Updates the roadmap status line to record the 2026-08-17 reshuffle: after copy mode (EPIC-10), a credible-daily-driver hardening push (EPIC-13: emulation correctness, bundled themes, GUI↔daemon reconnect, install path) runs ahead of the chrome and session-persistence epics, picking up the distribution work (idea 37) the phase lists never scheduled. Also qualifies "Phase 0 complete" — bundled themes and wide-char width were Phase 0 deliverables and are now folded into EPIC-13.

Reviewed via review-cycle (Codex clean; 3 code-reviewer findings fixed: unlocatable pull-forward claim, Phase 0 contradiction, ambiguous collisions with Phase 2 themes / Phase 4 reconnection).