### PR TITLE
chore(ci): pin Rust toolchain to 1.98.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,10 @@ runs:
         rustc --version
         cargo clippy --version
 
-    # rust-cache keys on the rustc it sees, so a pin bump invalidates cleanly,
-    # and it never caches ~/.cargo/bin — which mise's rust install now owns.
+    # rust-cache keys on the rustc it sees, so a pin bump invalidates cleanly.
+    # cache-bin defaults to true, which caches and cleans ~/.cargo/bin — the
+    # directory mise's rust install owns — so it must stay off.
     - name: Cache cargo
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      with:
+        cache-bin: 'false'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,25 +4,24 @@ description: Install mise and project toolchain
 runs:
   using: composite
   steps:
+    # mise installs the Rust toolchain pinned in .mise.toml, components
+    # included. A second toolchain action here would leave which `cargo` runs
+    # dependent on PATH ordering.
     - name: Install mise
-      uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+      uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       with:
         install: true
         cache: true
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      with:
-        components: clippy, rustfmt
+    - name: Toolchain provenance
+      shell: bash
+      run: |
+        echo "cargo -> $(command -v cargo)"
+        cargo --version
+        rustc --version
+        cargo clippy --version
 
+    # rust-cache keys on the rustc it sees, so a pin bump invalidates cleanly,
+    # and it never caches ~/.cargo/bin — which mise's rust install now owns.
     - name: Cache cargo
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/
-          ~/.cargo/git/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,14 @@
   "platformAutomerge": true,
   "platformCommit": "enabled",
   "commitBody": "",
-  "prConcurrentLimit": 5
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "description": "The Rust pin exists so a new clippy release never reaches main without a reviewed commit; automerging the pin would reintroduce exactly that. The mise manager sets packageName to a bare 'rust'.",
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["rust"],
+      "groupName": null,
+      "automerge": false
+    }
+  ]
 }

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,9 @@
 [tools]
-rust = "stable"
+# Exact, not `stable`: clippy runs under -D warnings, so a release that adds a
+# lint turns CI red with no commit anyone reviewed. `stable` also resolves
+# per-machine and per-install-date, which diverges local from CI. renovate.json
+# keeps this pin out of automerge so every move is reviewed.
+rust = { version = "1.98.0", components = "clippy,rustfmt" }
 lefthook = "2.1.10"
 dprint = "0.56.0"
 rumdl = "0.2.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ members = [
 edition = "2024"
 license = "MPL-2.0"
 repository = "https://github.com/oakoss/oakterm"
-rust-version = "1.85"
+# Equals .mise.toml's rust pin: one supported version, floor == ceiling. An
+# older toolchain gets `requires rustc 1.98.0` instead of a failure deep in a
+# dependency. Moving the pin moves this too.
+rust-version = "1.98.0"
 
 [workspace.dependencies]
 # Clipboard

--- a/crates/oakterm-config/src/init.rs
+++ b/crates/oakterm-config/src/init.rs
@@ -72,10 +72,10 @@ fn write_stubs(config_dir: &Path) -> io::Result<bool> {
     let stub_path = types_dir.join("oakterm.lua");
 
     // Skip write if content is identical (avoids unnecessary mtime changes).
-    if let Ok(existing) = std::fs::read_to_string(&stub_path) {
-        if existing == stubs::OAKTERM_LUA_STUB {
-            return Ok(false);
-        }
+    if let Ok(existing) = std::fs::read_to_string(&stub_path)
+        && existing == stubs::OAKTERM_LUA_STUB
+    {
+        return Ok(false);
     }
 
     atomic_write(&stub_path, stubs::OAKTERM_LUA_STUB)?;

--- a/crates/oakterm-config/src/keybind.rs
+++ b/crates/oakterm-config/src/keybind.rs
@@ -624,10 +624,10 @@ impl KeybindRegistry {
             .drain(..)
             .chain(self.leader_bindings.bindings.drain(..));
         for (_, action) in drained {
-            if let Action::Callback(key) = action {
-                if let Err(e) = lua.remove_registry_value(key) {
-                    tracing::warn!(error = %e, "failed to clean up keybind callback");
-                }
+            if let Action::Callback(key) = action
+                && let Err(e) = lua.remove_registry_value(key)
+            {
+                tracing::warn!(error = %e, "failed to clean up keybind callback");
             }
         }
     }

--- a/crates/oakterm-config/src/lib.rs
+++ b/crates/oakterm-config/src/lib.rs
@@ -194,10 +194,10 @@ pub fn config_dir() -> PathBuf {
     if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
         return PathBuf::from(xdg).join("oakterm");
     }
-    if cfg!(windows) {
-        if let Ok(appdata) = std::env::var("APPDATA") {
-            return PathBuf::from(appdata).join("oakterm");
-        }
+    if cfg!(windows)
+        && let Ok(appdata) = std::env::var("APPDATA")
+    {
+        return PathBuf::from(appdata).join("oakterm");
     }
     if let Ok(home) = std::env::var("HOME") {
         return PathBuf::from(home).join(".config").join("oakterm");
@@ -260,10 +260,10 @@ pub fn load_config_from(path: &Path) -> ConfigResult {
     // KeybindRegistry::with_defaults(); user binds override them there.
 
     // Install sandboxed require() for multi-file configs.
-    if let Some(parent) = path.parent() {
-        if let Err(e) = install_require(&lua, parent) {
-            tracing::warn!(error = %e, "failed to install require()");
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = install_require(&lua, parent)
+    {
+        tracing::warn!(error = %e, "failed to install require()");
     }
 
     if let Err(e) = lua.load(&source).set_name(path.to_string_lossy()).exec() {
@@ -346,11 +346,11 @@ fn install_require(lua: &Lua, config_dir: &Path) -> mlua::Result<()> {
         let cache: mlua::Table = lua.named_registry_value(MODULE_CACHE_KEY)?;
         let sentinel: mlua::Table = lua.named_registry_value(CIRCULAR_SENTINEL_KEY)?;
         if let Some(cached) = cache.get::<Option<Value>>(name_str.as_ref())? {
-            if let Value::Table(ref t) = cached {
-                if t == &sentinel {
-                    // Circular require: return true as placeholder.
-                    return Ok(Value::Boolean(true));
-                }
+            if let Value::Table(ref t) = cached
+                && t == &sentinel
+            {
+                // Circular require: return true as placeholder.
+                return Ok(Value::Boolean(true));
             }
             return Ok(cached);
         }

--- a/crates/oakterm-daemon/src/requests/input.rs
+++ b/crates/oakterm-daemon/src/requests/input.rs
@@ -38,10 +38,10 @@ pub(super) async fn key_input(
     };
     match &pane.pty_state {
         PtyState::Running { fd, .. } => {
-            if !msg.key_data.is_empty() {
-                if let Err(e) = rustix::io::write(fd, &msg.key_data) {
-                    warn!(conn_id, error = %e, "PTY write failed");
-                }
+            if !msg.key_data.is_empty()
+                && let Err(e) = rustix::io::write(fd, &msg.key_data)
+            {
+                warn!(conn_id, error = %e, "PTY write failed");
             }
         }
         PtyState::Exited { .. } | PtyState::Failed(_) => {
@@ -100,10 +100,10 @@ pub(super) async fn mouse_input(
 
         if should_send {
             let seq = encode_mouse_sgr(&msg, sgr);
-            if !seq.is_empty() {
-                if let Err(e) = rustix::io::write(fd, seq.as_bytes()) {
-                    warn!(conn_id, error = %e, "PTY mouse write failed");
-                }
+            if !seq.is_empty()
+                && let Err(e) = rustix::io::write(fd, seq.as_bytes())
+            {
+                warn!(conn_id, error = %e, "PTY mouse write failed");
             }
         } else if (msg.event_type == 3 || msg.event_type == 4) && on_alt && alt_scroll {
             let arrow: &[u8] = match (msg.event_type, decckm) {

--- a/crates/oakterm-daemon/src/server/mod.rs
+++ b/crates/oakterm-daemon/src/server/mod.rs
@@ -177,10 +177,10 @@ impl Daemon {
         // block on ServerHello until the process exits, seeing a raw reset
         // instead of the "daemon not running" path it already handles.
         drop(listener);
-        if let Err(e) = std::fs::remove_file(&self.socket_path) {
-            if e.kind() != io::ErrorKind::NotFound {
-                warn!(error = %e, "failed to remove socket during shutdown");
-            }
+        if let Err(e) = std::fs::remove_file(&self.socket_path)
+            && e.kind() != io::ErrorKind::NotFound
+        {
+            warn!(error = %e, "failed to remove socket during shutdown");
         }
 
         if drain_clients {
@@ -205,12 +205,11 @@ impl Daemon {
                 if let Err(e) = archive.shutdown() {
                     warn!(error = %e, "archive shutdown failed");
                 }
-                if let Some(p) = parent {
-                    if let Err(e) = std::fs::remove_dir(&p) {
-                        if e.kind() != std::io::ErrorKind::NotFound {
-                            warn!(error = %e, path = %p.display(), "failed to remove session directory");
-                        }
-                    }
+                if let Some(p) = parent
+                    && let Err(e) = std::fs::remove_dir(&p)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!(error = %e, path = %p.display(), "failed to remove session directory");
                 }
             }
         }
@@ -267,10 +266,10 @@ impl Daemon {
 
 impl Drop for Daemon {
     fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_file(&self.socket_path) {
-            if e.kind() != io::ErrorKind::NotFound {
-                warn!(error = %e, path = %self.socket_path.display(), "failed to remove socket on drop");
-            }
+        if let Err(e) = std::fs::remove_file(&self.socket_path)
+            && e.kind() != io::ErrorKind::NotFound
+        {
+            warn!(error = %e, path = %self.socket_path.display(), "failed to remove socket on drop");
         }
     }
 }
@@ -420,10 +419,10 @@ async fn dispatch_incoming(
         if frame.msg_type == MSG_REQUEST_SHUTDOWN {
             match request_shutdown(conn_id, &frame, panes, shutdown).await {
                 ShutdownOutcome::Accepted { ack } => {
-                    if let Some(ack) = ack {
-                        if io.write(ack).await.is_err() {
-                            return ControlFlow::Break(());
-                        }
+                    if let Some(ack) = ack
+                        && io.write(ack).await.is_err()
+                    {
+                        return ControlFlow::Break(());
                     }
                     // Pipelined frames after an accepted shutdown would
                     // mutate state the saved session no longer reflects; drop
@@ -431,10 +430,10 @@ async fn dispatch_incoming(
                     return ControlFlow::Continue(());
                 }
                 ShutdownOutcome::Declined { response } => {
-                    if let Some(response) = response {
-                        if io.write(response).await.is_err() {
-                            return ControlFlow::Break(());
-                        }
+                    if let Some(response) = response
+                        && io.write(response).await.is_err()
+                    {
+                        return ControlFlow::Break(());
                     }
                     continue;
                 }
@@ -590,14 +589,14 @@ async fn send_dirty_notifications(
             continue;
         }
         // PaneExited (once per pane).
-        if !pane_exit_sent.contains(&id) {
-            if let PtyState::Exited { exit_code } = pane.pty_state {
-                pane_exit_sent.insert(id);
-                exit_msgs.push(PaneExited {
-                    pane_id: id,
-                    exit_code,
-                });
-            }
+        if !pane_exit_sent.contains(&id)
+            && let PtyState::Exited { exit_code } = pane.pty_state
+        {
+            pane_exit_sent.insert(id);
+            exit_msgs.push(PaneExited {
+                pane_id: id,
+                exit_code,
+            });
         }
         // Title/bell flags are per-grid, not per-client. First client to
         // wake clears them; others miss the event. Phase 1 needs per-client

--- a/crates/oakterm-daemon/tests/integration.rs
+++ b/crates/oakterm-daemon/tests/integration.rs
@@ -824,10 +824,10 @@ async fn poll_for_pid(stream: &mut UnixStream, codec: &mut FrameCodec, target_pa
         let resp = read_response_with_serial(stream, codec, serial).await;
         assert_eq!(resp.msg_type, MSG_LIST_PANES_RESPONSE);
         let list = ListPanesResponse::decode(&resp.payload).expect("decode ListPanesResponse");
-        if let Some(info) = list.panes.iter().find(|p| p.pane_id == target_pane) {
-            if info.pid != 0 {
-                return info.pid;
-            }
+        if let Some(info) = list.panes.iter().find(|p| p.pane_id == target_pane)
+            && info.pid != 0
+        {
+            return info.pid;
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
@@ -1639,10 +1639,10 @@ async fn poll_tab_name(stream: &mut UnixStream, codec: &mut FrameCodec, tab_id: 
     while std::time::Instant::now() < deadline {
         serial += 1;
         let tabs = list_tabs_ok(stream, codec, serial).await;
-        if let Some(t) = tabs.tabs.iter().find(|t| t.tab_id == tab_id) {
-            if !t.name.is_empty() {
-                return t.name.clone();
-            }
+        if let Some(t) = tabs.tabs.iter().find(|t| t.tab_id == tab_id)
+            && !t.name.is_empty()
+        {
+            return t.name.clone();
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }

--- a/crates/oakterm-mux/src/geometry.rs
+++ b/crates/oakterm-mux/src/geometry.rs
@@ -217,14 +217,13 @@ pub(crate) fn locate_split_site(
         let LayoutNode::Container(c) = node else {
             return SplitSite::Halve { path };
         };
-        if c.direction == direction {
-            if let Some(target_pos) = c
+        if c.direction == direction
+            && let Some(target_pos) = c
                 .children
                 .iter()
                 .position(|ch| matches!(ch.node, LayoutNode::Leaf(id) if id == target))
-            {
-                return SplitSite::Sibling { path, target_pos };
-            }
+        {
+            return SplitSite::Sibling { path, target_pos };
         }
         let next = c
             .children

--- a/crates/oakterm-mux/src/layout.rs
+++ b/crates/oakterm-mux/src/layout.rs
@@ -209,10 +209,10 @@ impl LayoutNode {
         }
 
         for child in &c.children {
-            if let LayoutNode::Container(inner) = &child.node {
-                if inner.direction == c.direction {
-                    return Err(InvariantViolation::SameDirectionNesting);
-                }
+            if let LayoutNode::Container(inner) = &child.node
+                && inner.direction == c.direction
+            {
+                return Err(InvariantViolation::SameDirectionNesting);
             }
             child.node.validate()?;
         }

--- a/crates/oakterm-mux/src/ops.rs
+++ b/crates/oakterm-mux/src/ops.rs
@@ -266,10 +266,10 @@ fn remove_leaf(c: &mut Container, target: PaneId) -> LeafRemoval {
         return LeafRemoval::Removed { hint };
     }
     for child in &mut c.children {
-        if let LayoutNode::Container(inner) = &mut child.node {
-            if let LeafRemoval::Removed { hint } = remove_leaf(inner, target) {
-                return LeafRemoval::Removed { hint };
-            }
+        if let LayoutNode::Container(inner) = &mut child.node
+            && let LeafRemoval::Removed { hint } = remove_leaf(inner, target)
+        {
+            return LeafRemoval::Removed { hint };
         }
     }
     LeafRemoval::NotFound
@@ -1010,7 +1010,7 @@ mod tests {
             let op = lcg(&mut rng) % 3;
             if op == 0 && live.len() < 64 {
                 let target = live[lcg(&mut rng) as usize % live.len()];
-                let dir = if lcg(&mut rng) % 2 == 0 {
+                let dir = if lcg(&mut rng).is_multiple_of(2) {
                     Horizontal
                 } else {
                     Vertical

--- a/crates/oakterm-mux/src/state.rs
+++ b/crates/oakterm-mux/src/state.rs
@@ -158,10 +158,10 @@ impl Tab {
     /// [`LayoutError::PaneNotFound`] if `target` is not in the tree.
     pub(crate) fn close_pane(&mut self, target: PaneId) -> Result<CloseOutcome, LayoutError> {
         let outcome = self.layout.close(target)?;
-        if let CloseOutcome::Removed { focus_hint } = outcome {
-            if self.focused_pane == target {
-                self.focused_pane = focus_hint;
-            }
+        if let CloseOutcome::Removed { focus_hint } = outcome
+            && self.focused_pane == target
+        {
+            self.focused_pane = focus_hint;
         }
         Ok(outcome)
     }

--- a/crates/oakterm-pty/src/unix.rs
+++ b/crates/oakterm-pty/src/unix.rs
@@ -273,17 +273,17 @@ fn spawn_child(spec: CommandSpec, slave: OwnedFd) -> io::Result<Child> {
 /// is checked with `access(X_OK)`; non-executable candidates fall through with
 /// a `WARN` log so users can diagnose without strace.
 fn resolve_default_shell() -> PathBuf {
-    if let Ok(env_shell) = std::env::var("SHELL") {
-        if !env_shell.is_empty() {
-            let env_path = Path::new(&env_shell);
-            if is_executable(env_path) {
-                return PathBuf::from(env_shell);
-            }
-            warn!(
-                shell = %env_shell,
-                "$SHELL is not executable, falling back to passwd entry"
-            );
+    if let Ok(env_shell) = std::env::var("SHELL")
+        && !env_shell.is_empty()
+    {
+        let env_path = Path::new(&env_shell);
+        if is_executable(env_path) {
+            return PathBuf::from(env_shell);
         }
+        warn!(
+            shell = %env_shell,
+            "$SHELL is not executable, falling back to passwd entry"
+        );
     }
 
     if let Some(passwd_shell) = passwd_shell() {

--- a/crates/oakterm-renderer/src/font.rs
+++ b/crates/oakterm-renderer/src/font.rs
@@ -93,10 +93,10 @@ pub fn load_default_metrics(
             style: fontdb::Style::Normal,
         };
 
-        if let Some(id) = db.query(&query) {
-            if let Some((data, metrics)) = load_face(db, id, font_size) {
-                return Ok((metrics, data));
-            }
+        if let Some(id) = db.query(&query)
+            && let Some((data, metrics)) = load_face(db, id, font_size)
+        {
+            return Ok((metrics, data));
         }
     }
 
@@ -108,10 +108,10 @@ pub fn load_default_metrics(
         style: fontdb::Style::Normal,
     };
 
-    if let Some(id) = db.query(&query) {
-        if let Some((data, metrics)) = load_face(db, id, font_size) {
-            return Ok((metrics, data));
-        }
+    if let Some(id) = db.query(&query)
+        && let Some((data, metrics)) = load_face(db, id, font_size)
+    {
+        return Ok((metrics, data));
     }
 
     Err(io::Error::new(
@@ -191,15 +191,15 @@ pub fn load_default_variants(db: &fontdb::Database, font_size: f32) -> io::Resul
                 stretch: fontdb::Stretch::Normal,
                 style: fontdb::Style::Normal,
             };
-            if let Some(id) = db.query(&query) {
-                if let Some(face_info) = db.face(id) {
-                    let family_name = face_info
-                        .families
-                        .first()
-                        .map_or_else(String::new, |(name, _)| name.clone());
-                    if let Some(result) = load_face(db, id, font_size) {
-                        found = Some((family_name, result));
-                    }
+            if let Some(id) = db.query(&query)
+                && let Some(face_info) = db.face(id)
+            {
+                let family_name = face_info
+                    .families
+                    .first()
+                    .map_or_else(String::new, |(name, _)| name.clone());
+                if let Some(result) = load_face(db, id, font_size) {
+                    found = Some((family_name, result));
                 }
             }
         }

--- a/crates/oakterm-renderer/src/swash_shaper.rs
+++ b/crates/oakterm-renderer/src/swash_shaper.rs
@@ -479,10 +479,10 @@ mod tests {
             return;
         };
         let db = font::system_font_db();
-        if let Ok((_m, data)) = font::load_default_metrics(&db, 14.0) {
-            if let Some(fb) = shaper.load_font(data, 0, 14.0) {
-                shaper.set_fallback_chain(vec![fb]);
-            }
+        if let Ok((_m, data)) = font::load_default_metrics(&db, 14.0)
+            && let Some(fb) = shaper.load_font(data, 0, 14.0)
+        {
+            shaper.set_fallback_chain(vec![fb]);
         }
         let run = TextRun {
             text: "\u{10FFFD}",

--- a/crates/oakterm-terminal/benches/scroll_archive.rs
+++ b/crates/oakterm-terminal/benches/scroll_archive.rs
@@ -28,10 +28,10 @@ fn push_rows(hot: &mut HotBuffer, archive: Option<&mut ArchiveManager>, template
     let mut archive = archive;
     for _ in 0..ROWS_PER_ITER {
         let pruned = hot.push(template.clone());
-        if !pruned.is_empty() {
-            if let Some(mgr) = archive.as_deref_mut() {
-                mgr.archive_rows(pruned).expect("archive_rows");
-            }
+        if !pruned.is_empty()
+            && let Some(mgr) = archive.as_deref_mut()
+        {
+            mgr.archive_rows(pruned).expect("archive_rows");
         }
     }
 }

--- a/crates/oakterm-terminal/src/grid/cell.rs
+++ b/crates/oakterm-terminal/src/grid/cell.rs
@@ -233,11 +233,11 @@ impl Cell {
     }
 
     pub fn clear_graphemes(&mut self) {
-        if let Some(e) = &mut self.extra {
-            if !e.graphemes.is_empty() {
-                e.graphemes.clear();
-                self.drop_extra_if_empty();
-            }
+        if let Some(e) = &mut self.extra
+            && !e.graphemes.is_empty()
+        {
+            e.graphemes.clear();
+            self.drop_extra_if_empty();
         }
     }
 
@@ -257,10 +257,12 @@ impl Cell {
     }
 
     fn drop_extra_if_empty(&mut self) {
-        if let Some(e) = &self.extra {
-            if e.graphemes.is_empty() && e.underline_color.is_none() && e.hyperlink.is_none() {
-                self.extra = None;
-            }
+        if let Some(e) = &self.extra
+            && e.graphemes.is_empty()
+            && e.underline_color.is_none()
+            && e.hyperlink.is_none()
+        {
+            self.extra = None;
         }
     }
 }

--- a/crates/oakterm-terminal/src/grid/mod.rs
+++ b/crates/oakterm-terminal/src/grid/mod.rs
@@ -506,12 +506,11 @@ impl ScreenSet {
     /// Push a row to the hot buffer, archiving any pruned rows to disk.
     pub fn push_to_scrollback(&mut self, row: Row) {
         let pruned = self.scrollback.push(row);
-        if !pruned.is_empty() {
-            if let Some(archive) = &mut self.archive {
-                if let Err(e) = archive.archive_rows(pruned) {
-                    tracing::warn!(error = %e, "failed to archive pruned rows");
-                }
-            }
+        if !pruned.is_empty()
+            && let Some(archive) = &mut self.archive
+            && let Err(e) = archive.archive_rows(pruned)
+        {
+            tracing::warn!(error = %e, "failed to archive pruned rows");
         }
     }
 

--- a/crates/oakterm-terminal/src/scroll/archive.rs
+++ b/crates/oakterm-terminal/src/scroll/archive.rs
@@ -158,7 +158,7 @@ pub fn deserialize_seek_table(data: &[u8]) -> io::Result<Vec<SeekTableEntry>> {
     }
     let mut entries = Vec::with_capacity(data.len() / SEEK_ENTRY_SIZE);
     for chunk in data.as_chunks::<SEEK_ENTRY_SIZE>().0 {
-        // chunks_exact guarantees 28 bytes; array conversions are infallible.
+        // as_chunks yields &[u8; 28]; array conversions are infallible.
         let u64_at =
             |off| u64::from_le_bytes(chunk[off..off + 8].try_into().expect("28-byte chunk"));
         let u32_at =

--- a/crates/oakterm-terminal/src/scroll/archive.rs
+++ b/crates/oakterm-terminal/src/scroll/archive.rs
@@ -147,7 +147,7 @@ pub fn serialize_seek_table(entries: &[SeekTableEntry]) -> Vec<u8> {
 ///
 /// Cannot panic: the size check ensures each chunk is exactly 28 bytes.
 pub fn deserialize_seek_table(data: &[u8]) -> io::Result<Vec<SeekTableEntry>> {
-    if data.len() % SEEK_ENTRY_SIZE != 0 {
+    if !data.len().is_multiple_of(SEEK_ENTRY_SIZE) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
@@ -157,7 +157,7 @@ pub fn deserialize_seek_table(data: &[u8]) -> io::Result<Vec<SeekTableEntry>> {
         ));
     }
     let mut entries = Vec::with_capacity(data.len() / SEEK_ENTRY_SIZE);
-    for chunk in data.chunks_exact(SEEK_ENTRY_SIZE) {
+    for chunk in data.as_chunks::<SEEK_ENTRY_SIZE>().0 {
         // chunks_exact guarantees 28 bytes; array conversions are infallible.
         let u64_at =
             |off| u64::from_le_bytes(chunk[off..off + 8].try_into().expect("28-byte chunk"));

--- a/crates/oakterm-terminal/src/scroll/archive_core.rs
+++ b/crates/oakterm-terminal/src/scroll/archive_core.rs
@@ -125,10 +125,10 @@ impl<S: SegmentStorage> ArchiveCore<S> {
     /// Disk-space check, rate-limited to once per second — flushes can run
     /// thousands of times per second under sustained scrolling.
     fn disk_space_ok(&mut self) -> bool {
-        if let Some(last) = self.last_disk_check {
-            if last.elapsed() < std::time::Duration::from_secs(1) {
-                return !self.archiving_paused;
-            }
+        if let Some(last) = self.last_disk_check
+            && last.elapsed() < std::time::Duration::from_secs(1)
+        {
+            return !self.archiving_paused;
         }
         self.last_disk_check = Some(std::time::Instant::now());
         self.storage.has_enough_space(&self.session_dir)
@@ -296,10 +296,10 @@ impl<S: SegmentStorage> ArchiveCore<S> {
             // first_row_index is stamped at finalize, so close it before
             // advancing the index base. Failure routes through
             // discard_failed_segment, which accounts and pauses.
-            if self.active.is_some() {
-                if let Err(e) = self.finalize_active_segment() {
-                    tracing::warn!(error = %e, "seal before pause failed");
-                }
+            if self.active.is_some()
+                && let Err(e) = self.finalize_active_segment()
+            {
+                tracing::warn!(error = %e, "seal before pause failed");
             }
             let lost = self.pending_rows.len() as u64;
             self.lose_unfinalized(lost);

--- a/crates/oakterm-terminal/src/shell_integration.rs
+++ b/crates/oakterm-terminal/src/shell_integration.rs
@@ -242,12 +242,13 @@ fn percent_decode(s: &str) -> String {
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
-                out.push(hi * 16 + lo);
-                i += 3;
-                continue;
-            }
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2]))
+        {
+            out.push(hi * 16 + lo);
+            i += 3;
+            continue;
         }
         out.push(bytes[i]);
         i += 1;

--- a/crates/oakterm/src/copy_mode.rs
+++ b/crates/oakterm/src/copy_mode.rs
@@ -148,10 +148,10 @@ impl ViewportCache {
             return false;
         }
         let served_end = served_start.saturating_add(i64::try_from(rows.len()).unwrap_or(i64::MAX));
-        if let (Some(start), Some(end)) = (self.start(), self.end()) {
-            if served_start > end || served_end < start {
-                return false;
-            }
+        if let (Some(start), Some(end)) = (self.start(), self.end())
+            && (served_start > end || served_end < start)
+        {
+            return false;
         }
         for (i, row) in rows.into_iter().enumerate() {
             let index = i64::try_from(i).unwrap_or(i64::MAX);

--- a/crates/oakterm/src/daemon_conn.rs
+++ b/crates/oakterm/src/daemon_conn.rs
@@ -91,16 +91,16 @@ pub(crate) fn connect_to_daemon(
     }
 
     // We hold the lock and no daemon is running. Clean up stale socket.
-    if let Err(e) = std::fs::remove_file(&socket_path) {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(std::io::Error::new(
-                e.kind(),
-                format!(
-                    "failed to remove stale socket at {}: {e}",
-                    socket_path.display()
-                ),
-            ));
-        }
+    if let Err(e) = std::fs::remove_file(&socket_path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(std::io::Error::new(
+            e.kind(),
+            format!(
+                "failed to remove stale socket at {}: {e}",
+                socket_path.display()
+            ),
+        ));
     }
 
     let child = spawn_daemon(&socket_path)?;
@@ -410,15 +410,14 @@ fn daemon_reader(
                         let _ = proxy.send_event(UserEvent::RenderUpdate(Box::new(update)));
                         if let UpdateOutcome::SendFollowUp(since_seqno) =
                             state.on_render_update(pane_id, seqno)
+                            && let Err(e) = send_get_render_update(pane_id, since_seqno, writer)
                         {
-                            if let Err(e) = send_get_render_update(pane_id, since_seqno, writer) {
-                                // Same phantom-in_flight caveat as the
-                                // DirtyNotify arm above; safe only because we
-                                // break.
-                                error!(error = %e, "daemon write error");
-                                notify_disconnected(proxy);
-                                break;
-                            }
+                            // Same phantom-in_flight caveat as the
+                            // DirtyNotify arm above; safe only because we
+                            // break.
+                            error!(error = %e, "daemon write error");
+                            notify_disconnected(proxy);
+                            break;
                         }
                     }
                     Err(e) => {

--- a/crates/oakterm/src/input.rs
+++ b/crates/oakterm/src/input.rs
@@ -6,10 +6,10 @@ use winit::keyboard::{Key, KeyCode, NamedKey, PhysicalKey};
 /// Convert a winit key event to PTY bytes.
 #[must_use]
 pub(crate) fn key_to_bytes(key: &Key, text: Option<&str>) -> Option<Vec<u8>> {
-    if let Some(t) = text {
-        if !t.is_empty() {
-            return Some(t.as_bytes().to_vec());
-        }
+    if let Some(t) = text
+        && !t.is_empty()
+    {
+        return Some(t.as_bytes().to_vec());
     }
 
     if let Key::Named(named) = key {
@@ -189,12 +189,14 @@ pub(crate) fn palette_key_effect(
         Key::Character(s) if mods.control_key() && s.as_str() == "p" => PaletteKeyEffect::MoveUp,
         Key::Character(s) if mods.control_key() && s.as_str() == "n" => PaletteKeyEffect::MoveDown,
         _ => {
-            if !mods.control_key() && !mods.super_key() && !mods.alt_key() {
-                if let Some(text) = text {
-                    let printable: String = text.chars().filter(|c| !c.is_control()).collect();
-                    if !printable.is_empty() {
-                        return PaletteKeyEffect::Input(printable);
-                    }
+            if !mods.control_key()
+                && !mods.super_key()
+                && !mods.alt_key()
+                && let Some(text) = text
+            {
+                let printable: String = text.chars().filter(|c| !c.is_control()).collect();
+                if !printable.is_empty() {
+                    return PaletteKeyEffect::Input(printable);
                 }
             }
             PaletteKeyEffect::Ignore
@@ -273,10 +275,10 @@ pub(crate) fn resolve_key(
         return either(&|c| ctx.registry.lookup_leader_index(c))
             .map_or(miss, KeyDispatch::LeaderAction);
     }
-    if let Some(lk) = ctx.leader {
-        if logical == Some(&lk.chord) || physical == Some(&lk.chord) {
-            return KeyDispatch::LeaderArm(lk.timeout_ms);
-        }
+    if let Some(lk) = ctx.leader
+        && (logical == Some(&lk.chord) || physical == Some(&lk.chord))
+    {
+        return KeyDispatch::LeaderArm(lk.timeout_ms);
     }
     if ctx.copy_mode {
         return KeyDispatch::CopyMode;

--- a/crates/oakterm/src/main.rs
+++ b/crates/oakterm/src/main.rs
@@ -974,10 +974,10 @@ impl App {
             .get(&pane_id)
             .and_then(PaneView::copy_mode_pending_prefix);
         let (next, command) = copy_keys::advance_copy_key(pending, press);
-        if pending != next {
-            if let Some(view) = self.panes.get_mut(&pane_id) {
-                view.set_copy_mode_pending_prefix(next);
-            }
+        if pending != next
+            && let Some(view) = self.panes.get_mut(&pane_id)
+        {
+            view.set_copy_mode_pending_prefix(next);
         }
         if let Some(command) = command {
             self.run_copy_mode_command(pane_id, command);
@@ -1211,21 +1211,21 @@ impl App {
         match self.click_count {
             2 => {
                 // Semantic (word) selection.
-                if let Some(view) = self.focused_view_mut() {
-                    if row < view.grid().rows {
-                        let text: Vec<char> = view.grid().row_text(row).chars().collect();
-                        // Click past end of text: no word to select.
-                        if (col as usize) < text.len() {
-                            let (start_col, end_col) = word_boundaries(&text, col);
-                            let mut sel = Selection::new(
-                                SelectionType::Semantic,
-                                sel_row,
-                                start_col,
-                                AnchorSide::Left,
-                            );
-                            sel.update(sel_row, end_col, AnchorSide::Right);
-                            view.selection = Some(sel);
-                        }
+                if let Some(view) = self.focused_view_mut()
+                    && row < view.grid().rows
+                {
+                    let text: Vec<char> = view.grid().row_text(row).chars().collect();
+                    // Click past end of text: no word to select.
+                    if (col as usize) < text.len() {
+                        let (start_col, end_col) = word_boundaries(&text, col);
+                        let mut sel = Selection::new(
+                            SelectionType::Semantic,
+                            sel_row,
+                            start_col,
+                            AnchorSide::Left,
+                        );
+                        sel.update(sel_row, end_col, AnchorSide::Right);
+                        view.selection = Some(sel);
                     }
                 }
             }
@@ -1494,18 +1494,18 @@ impl ApplicationHandler<UserEvent> for App {
         self.action_registry = oakterm_config::ActionRegistry::core(&self.keybind_registry);
         self.lua_vm = cr.lua;
         // Fire config.loaded event for initial load.
-        if self.config_error.is_none() {
-            if let Some(lua) = &self.lua_vm {
-                for result in self.event_registry.fire(lua, "config.loaded", &[]) {
-                    match result {
-                        oakterm_config::HandlerResult::Error(e) => {
-                            warn!(error = %e, "config.loaded handler error");
-                        }
-                        oakterm_config::HandlerResult::Timeout => {
-                            warn!("config.loaded handler timed out (100ms limit)");
-                        }
-                        _ => {}
+        if self.config_error.is_none()
+            && let Some(lua) = &self.lua_vm
+        {
+            for result in self.event_registry.fire(lua, "config.loaded", &[]) {
+                match result {
+                    oakterm_config::HandlerResult::Error(e) => {
+                        warn!(error = %e, "config.loaded handler error");
                     }
+                    oakterm_config::HandlerResult::Timeout => {
+                        warn!("config.loaded handler timed out (100ms limit)");
+                    }
+                    _ => {}
                 }
             }
         }
@@ -1527,10 +1527,10 @@ impl ApplicationHandler<UserEvent> for App {
 
         match event {
             WindowEvent::CloseRequested => {
-                if let Some(daemon) = &mut self.daemon {
-                    if let Ok(frame) = Frame::new(MSG_DETACH, 0, vec![]) {
-                        let _ = daemon.send_frame(&frame); // Best-effort on exit.
-                    }
+                if let Some(daemon) = &mut self.daemon
+                    && let Ok(frame) = Frame::new(MSG_DETACH, 0, vec![])
+                {
+                    let _ = daemon.send_frame(&frame); // Best-effort on exit.
                 }
                 event_loop.exit();
             }
@@ -1820,10 +1820,9 @@ impl ApplicationHandler<UserEvent> for App {
                 {
                     if button == winit::event::MouseButton::Left
                         && self.last_mouse_pixel.1 < f64::from(self.tab_bar_px())
+                        && let Some(tab_id) = self.tab_at_pixel(self.last_mouse_pixel.0)
                     {
-                        if let Some(tab_id) = self.tab_at_pixel(self.last_mouse_pixel.0) {
-                            self.switch_tab(tab_id);
-                        }
+                        self.switch_tab(tab_id);
                     }
                     self.chrome_pressed_buttons |= bar_bit;
                     return;
@@ -2025,10 +2024,9 @@ impl ApplicationHandler<UserEvent> for App {
                     if self
                         .layout
                         .pane_is_visible(update.pane_id, self.focused_pane)
+                        && let Some(w) = &self.window
                     {
-                        if let Some(w) = &self.window {
-                            w.request_redraw();
-                        }
+                        w.request_redraw();
                     }
                 }
 
@@ -2119,13 +2117,13 @@ impl ApplicationHandler<UserEvent> for App {
                 if let Some(view) = self.panes.get_mut(&pane_id) {
                     view.title.clone_from(&title);
                 }
-                if pane_id == self.focused_pane {
-                    if let Some(w) = &self.window {
-                        let display = if title.is_empty() { "oakterm" } else { &title };
-                        w.set_title(display);
-                        // The status bar shows the focused pane's title.
-                        w.request_redraw();
-                    }
+                if pane_id == self.focused_pane
+                    && let Some(w) = &self.window
+                {
+                    let display = if title.is_empty() { "oakterm" } else { &title };
+                    w.set_title(display);
+                    // The status bar shows the focused pane's title.
+                    w.request_redraw();
                 }
                 // Unnamed tab labels mirror pane titles; re-ask the daemon
                 // (its naming rule is authoritative) while the bar shows.
@@ -2452,11 +2450,11 @@ impl App {
         // Performable gate (ADR-0011): an action that cannot run in the
         // current context releases the key to the PTY instead of
         // consuming it (Ghostty's `performable:` semantics, per-action).
-        if let Some(id) = oakterm_config::action_id_of(action) {
-            if !id.is_performable(self.action_context()) {
-                tracing::debug!(action = ?id, "keybind not performable here; key released to PTY");
-                return false;
-            }
+        if let Some(id) = oakterm_config::action_id_of(action)
+            && !id.is_performable(self.action_context())
+        {
+            tracing::debug!(action = ?id, "keybind not performable here; key released to PTY");
+            return false;
         }
         let action_desc = match desc_of_action(action) {
             DescOutcome::Desc(d) => d,
@@ -2530,11 +2528,11 @@ impl App {
             );
             return;
         };
-        if let Some(id) = oakterm_config::action_id_of(action) {
-            if !id.is_performable(self.action_context()) {
-                tracing::debug!(action = ?id, "leader action not performable here; consumed");
-                return;
-            }
+        if let Some(id) = oakterm_config::action_id_of(action)
+            && !id.is_performable(self.action_context())
+        {
+            tracing::debug!(action = ?id, "leader action not performable here; consumed");
+            return;
         }
         let action_desc = match desc_of_action(action) {
             DescOutcome::Desc(d) => d,
@@ -3134,10 +3132,8 @@ impl App {
                 false
             }
         };
-        if sent {
-            if let Some(view) = self.panes.get_mut(&pane_id) {
-                view.last_sent_dims = dims;
-            }
+        if sent && let Some(view) = self.panes.get_mut(&pane_id) {
+            view.last_sent_dims = dims;
         }
         sent
     }
@@ -3347,16 +3343,16 @@ impl App {
         // single-pane path below sizes to the whole window.
         if self.layout.has_tree() {
             let content = self.content_rect();
-            if let Some(c) = &content {
-                if c.width == 0 || c.height == 0 {
-                    // Grid sizing floors at 1x1, so panes silently stop
-                    // painting without this trace of why.
-                    warn!(
-                        width = c.width,
-                        height = c.height,
-                        "content area collapsed; window smaller than padding + chrome"
-                    );
-                }
+            if let Some(c) = &content
+                && (c.width == 0 || c.height == 0)
+            {
+                // Grid sizing floors at 1x1, so panes silently stop
+                // painting without this trace of why.
+                warn!(
+                    width = c.width,
+                    height = c.height,
+                    "content area collapsed; window smaller than padding + chrome"
+                );
             }
             self.layout.recompute(content);
             if self.layout.active_geometry().is_some() {
@@ -3556,104 +3552,96 @@ impl App {
             debug!("config reloaded successfully");
         }
 
-        if font_changed {
-            if let Some(window) = &self.window {
-                #[allow(clippy::cast_possible_truncation)]
-                #[allow(clippy::cast_possible_truncation)]
-                let font_size_pt = self.config.font_size as f32;
-                #[allow(clippy::cast_possible_truncation)]
-                let font_size = font_size_pt * window.scale_factor() as f32;
+        if font_changed && let Some(window) = &self.window {
+            #[allow(clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_possible_truncation)]
+            let font_size_pt = self.config.font_size as f32;
+            #[allow(clippy::cast_possible_truncation)]
+            let font_size = font_size_pt * window.scale_factor() as f32;
 
-                let font_state = match try_init_font(&self.config, font_size) {
-                    Ok(fs) => fs,
-                    Err(e) => {
-                        warn!(error = %e, "config reload: font init failed");
-                        self.config_error = Some(e);
-                        return;
-                    }
-                };
+            let font_state = match try_init_font(&self.config, font_size) {
+                Ok(fs) => fs,
+                Err(e) => {
+                    warn!(error = %e, "config reload: font init failed");
+                    self.config_error = Some(e);
+                    return;
+                }
+            };
 
-                // self.font still holds the old metrics; use font_state's.
-                let tab_px =
-                    tab_bar::tab_bar_height(self.tabs.bar_visible(), Some(font_state.metrics()));
-                let status_px = status_bar::status_bar_height(
-                    self.config.status_bar,
-                    Some(font_state.metrics()),
+            // self.font still holds the old metrics; use font_state's.
+            let tab_px =
+                tab_bar::tab_bar_height(self.tabs.bar_visible(), Some(font_state.metrics()));
+            let status_px =
+                status_bar::status_bar_height(self.config.status_bar, Some(font_state.metrics()));
+            let (top_px, bottom_px) =
+                chrome_split(tab_px, status_px, self.config.status_bar_position);
+            let mut copy_mode_exited = false;
+            let pending_resize = if let (Some(gpu), Some(view)) =
+                (&self.gpu, self.panes.get_mut(&self.focused_pane))
+            {
+                let phys = PhysicalSize::new(gpu.config.width, gpu.config.height);
+                let (cols, rows) = window_to_grid_dims(
+                    phys,
+                    font_state.metrics(),
+                    &self.config.padding,
+                    top_px,
+                    bottom_px,
                 );
-                let (top_px, bottom_px) =
-                    chrome_split(tab_px, status_px, self.config.status_bar_position);
-                let mut copy_mode_exited = false;
-                let pending_resize = if let (Some(gpu), Some(view)) =
-                    (&self.gpu, self.panes.get_mut(&self.focused_pane))
-                {
-                    let phys = PhysicalSize::new(gpu.config.width, gpu.config.height);
-                    let (cols, rows) = window_to_grid_dims(
-                        phys,
-                        font_state.metrics(),
-                        &self.config.padding,
-                        top_px,
-                        bottom_px,
-                    );
-                    let cols = cols.max(1);
-                    let rows = rows.max(1);
-                    copy_mode_exited = view.resize(cols, rows);
+                let cols = cols.max(1);
+                let rows = rows.max(1);
+                copy_mode_exited = view.resize(cols, rows);
 
-                    // Row bounds derive from cell dimensions; rebuild the
-                    // a11y tree at the new metrics.
-                    match self.a11y_state.lock() {
-                        Ok(mut model) => {
-                            if let Some(m) = model.as_mut() {
-                                m.set_cell_dims(a11y_bridge::cell_dims(Some(font_state.metrics())));
-                            }
+                // Row bounds derive from cell dimensions; rebuild the
+                // a11y tree at the new metrics.
+                match self.a11y_state.lock() {
+                    Ok(mut model) => {
+                        if let Some(m) = model.as_mut() {
+                            m.set_cell_dims(a11y_bridge::cell_dims(Some(font_state.metrics())));
                         }
-                        Err(e) => warn!(error = %e, "a11y: mutex poisoned on font change"),
                     }
-                    let full_tree = a11y_bridge::apply(
-                        &self.a11y_state,
-                        self.focused_pane,
-                        view,
-                        A11yEvent::Resize,
-                    );
-                    if let (Some(adapter), Some(full_tree)) = (&mut self.accesskit, full_tree) {
-                        adapter.update_if_active(|| full_tree);
-                    }
-
-                    Some(window_resize(self.focused_pane, (cols, rows), phys))
-                } else {
-                    // The renderer adopts the new metrics below; without a
-                    // grid resize the a11y model and daemon keep the old
-                    // geometry.
-                    warn!("config reload: font changed but gpu/view unavailable");
-                    None
-                };
-                let focused = self.focused_pane;
-                self.release_copy_mode_pin(focused, copy_mode_exited);
-                if let Some(msg) = pending_resize {
-                    self.send_resize(msg);
+                    Err(e) => warn!(error = %e, "a11y: mutex poisoned on font change"),
+                }
+                let full_tree = a11y_bridge::apply(
+                    &self.a11y_state,
+                    self.focused_pane,
+                    view,
+                    A11yEvent::Resize,
+                );
+                if let (Some(adapter), Some(full_tree)) = (&mut self.accesskit, full_tree) {
+                    adapter.update_if_active(|| full_tree);
                 }
 
-                self.font = Some(font_state);
+                Some(window_resize(self.focused_pane, (cols, rows), phys))
+            } else {
+                // The renderer adopts the new metrics below; without a
+                // grid resize the a11y model and daemon keep the old
+                // geometry.
+                warn!("config reload: font changed but gpu/view unavailable");
+                None
+            };
+            let focused = self.focused_pane;
+            self.release_copy_mode_pin(focused, copy_mode_exited);
+            if let Some(msg) = pending_resize {
+                self.send_resize(msg);
             }
+
+            self.font = Some(font_state);
         }
 
         // Recreate GPU pipeline if blending mode changed (baked into shader).
-        if blending_changed {
-            if let Some(gpu) = &mut self.gpu {
-                let blending_mode = match self.config.text_blending {
-                    oakterm_config::TextBlending::Linear => {
-                        oakterm_renderer::shaders::BLENDING_LINEAR
-                    }
-                    oakterm_config::TextBlending::LinearCorrected => {
-                        oakterm_renderer::shaders::BLENDING_LINEAR_CORRECTED
-                    }
-                };
-                gpu.pipeline = oakterm_renderer::pipeline::RenderPipeline::new(
-                    &gpu.device,
-                    gpu.config.format,
-                    blending_mode,
-                    gpu.p3_active,
-                );
-            }
+        if blending_changed && let Some(gpu) = &mut self.gpu {
+            let blending_mode = match self.config.text_blending {
+                oakterm_config::TextBlending::Linear => oakterm_renderer::shaders::BLENDING_LINEAR,
+                oakterm_config::TextBlending::LinearCorrected => {
+                    oakterm_renderer::shaders::BLENDING_LINEAR_CORRECTED
+                }
+            };
+            gpu.pipeline = oakterm_renderer::pipeline::RenderPipeline::new(
+                &gpu.device,
+                gpu.config.format,
+                blending_mode,
+                gpu.p3_active,
+            );
         }
 
         // Status bar changes move the content area. Runs after the font

--- a/crates/oakterm/src/main.rs
+++ b/crates/oakterm/src/main.rs
@@ -3554,7 +3554,6 @@ impl App {
 
         if font_changed && let Some(window) = &self.window {
             #[allow(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_possible_truncation)]
             let font_size_pt = self.config.font_size as f32;
             #[allow(clippy::cast_possible_truncation)]
             let font_size = font_size_pt * window.scale_factor() as f32;

--- a/crates/oakterm/src/render.rs
+++ b/crates/oakterm/src/render.rs
@@ -116,19 +116,19 @@ impl App {
         // The palette assembles after everything else so its panel covers
         // pane content and split borders; it also drops the pane glyphs
         // beneath it (text has no z-order).
-        if self.palette.is_visible() {
-            if let Some(font) = &mut self.font {
-                let mut overlay = FrameAssembly {
-                    glyphs: std::mem::take(&mut glyph_instances),
-                    ..Default::default()
-                };
-                // Full top chrome, so the palette clears a top status bar.
-                assemble_palette(font, &self.palette, viewport, top_chrome, &mut overlay);
-                gpu.upload_glyphs(font.atlas(), &overlay.uploads);
-                gpu.upload_color_glyphs(font.color_atlas(), &overlay.color_uploads);
-                bg_sections.extend(overlay.bg_sections);
-                glyph_instances = overlay.glyphs;
-            }
+        if self.palette.is_visible()
+            && let Some(font) = &mut self.font
+        {
+            let mut overlay = FrameAssembly {
+                glyphs: std::mem::take(&mut glyph_instances),
+                ..Default::default()
+            };
+            // Full top chrome, so the palette clears a top status bar.
+            assemble_palette(font, &self.palette, viewport, top_chrome, &mut overlay);
+            gpu.upload_glyphs(font.atlas(), &overlay.uploads);
+            gpu.upload_color_glyphs(font.color_atlas(), &overlay.color_uploads);
+            bg_sections.extend(overlay.bg_sections);
+            glyph_instances = overlay.glyphs;
         }
 
         let uniforms = text_uniforms(self.font.as_ref(), self.config.text_gamma, viewport);

--- a/crates/oakterm/src/render_grid.rs
+++ b/crates/oakterm/src/render_grid.rs
@@ -274,17 +274,17 @@ impl ClientGrid {
         }
 
         // Bottom portion: live snapshot rows (if partial scroll).
-        if sb_display_rows < rows {
-            if let Some(snap) = &self.live_snapshot {
-                let live_start = 0;
-                let live_count = rows - sb_display_rows;
-                for i in 0..live_count {
-                    let src_idx = (live_start + i) * cols;
-                    let dst_idx = (sb_display_rows + i) * cols;
-                    if src_idx + cols <= snap.cells.len() && dst_idx + cols <= self.cells.len() {
-                        self.cells[dst_idx..dst_idx + cols]
-                            .clone_from_slice(&snap.cells[src_idx..src_idx + cols]);
-                    }
+        if sb_display_rows < rows
+            && let Some(snap) = &self.live_snapshot
+        {
+            let live_start = 0;
+            let live_count = rows - sb_display_rows;
+            for i in 0..live_count {
+                let src_idx = (live_start + i) * cols;
+                let dst_idx = (sb_display_rows + i) * cols;
+                if src_idx + cols <= snap.cells.len() && dst_idx + cols <= self.cells.len() {
+                    self.cells[dst_idx..dst_idx + cols]
+                        .clone_from_slice(&snap.cells[src_idx..src_idx + cols]);
                 }
             }
         }
@@ -597,49 +597,49 @@ impl ClientGrid {
 
         // Emit a sub-cell cursor quad for underline or bar styles.
         let cursor_shape = cursor_shape_from_wire(self.cursor_style);
-        if cursor_shape != 0 {
-            if let Some(_cursor_idx) = cursor_idx {
-                let cx = f32::from(self.cursor_x) * metrics.cell_width + pad_left;
-                let cy = f32::from(self.cursor_y) * metrics.cell_height + pad_top;
+        if cursor_shape != 0
+            && let Some(_cursor_idx) = cursor_idx
+        {
+            let cx = f32::from(self.cursor_x) * metrics.cell_width + pad_left;
+            let cy = f32::from(self.cursor_y) * metrics.cell_height + pad_top;
 
-                // Use the cell's fg color for the cursor line.
-                let cell_idx = usize::from(self.cursor_y) * usize::from(self.cols)
-                    + usize::from(self.cursor_x);
-                let cursor_fg = if cell_idx < self.cells.len() {
-                    self.cells[cell_idx].fg
-                } else {
-                    [255, 255, 255]
-                };
-                let fg = [
-                    f32::from(cursor_fg[0]) / 255.0,
-                    f32::from(cursor_fg[1]) / 255.0,
-                    f32::from(cursor_fg[2]) / 255.0,
-                    1.0,
-                ];
+            // Use the cell's fg color for the cursor line.
+            let cell_idx =
+                usize::from(self.cursor_y) * usize::from(self.cols) + usize::from(self.cursor_x);
+            let cursor_fg = if cell_idx < self.cells.len() {
+                self.cells[cell_idx].fg
+            } else {
+                [255, 255, 255]
+            };
+            let fg = [
+                f32::from(cursor_fg[0]) / 255.0,
+                f32::from(cursor_fg[1]) / 255.0,
+                f32::from(cursor_fg[2]) / 255.0,
+                1.0,
+            ];
 
-                let (pos, size) = if cursor_shape == 1 {
-                    // Underline: thin line at cell bottom.
-                    (
-                        [cx, cy + metrics.cell_height - 2.0],
-                        [metrics.cell_width, 2.0],
-                    )
-                } else {
-                    // Bar: thin line at cell left edge.
-                    ([cx, cy], [2.0, metrics.cell_height])
-                };
+            let (pos, size) = if cursor_shape == 1 {
+                // Underline: thin line at cell bottom.
+                (
+                    [cx, cy + metrics.cell_height - 2.0],
+                    [metrics.cell_width, 2.0],
+                )
+            } else {
+                // Bar: thin line at cell left edge.
+                ([cx, cy], [2.0, metrics.cell_height])
+            };
 
-                // UV is unused — the bg_luminance sentinel causes the shader
-                // to output solid fg_color before sampling the atlas.
-                glyphs.push(GlyphVertex {
-                    pos,
-                    size,
-                    uv_origin: [0.0, 0.0],
-                    fg_color: fg,
-                    bg_luminance: -1.0,
-                    is_color: 0.0,
-                    pad: [0.0; 2],
-                });
-            }
+            // UV is unused — the bg_luminance sentinel causes the shader
+            // to output solid fg_color before sampling the atlas.
+            glyphs.push(GlyphVertex {
+                pos,
+                size,
+                uv_origin: [0.0, 0.0],
+                fg_color: fg,
+                bg_luminance: -1.0,
+                is_color: 0.0,
+                pad: [0.0; 2],
+            });
         }
 
         atlas.clear_in_use();


### PR DESCRIPTION
## Summary

Pins the Rust toolchain to an exact version and aligns the MSRV to it, following oakum's pattern (ADR-0025 there). `rust = "stable"` resolved per-machine and per-install-date: CI silently adopted clippy 1.98 (which broke #57 on pre-existing code) while local machines sat on 1.94. With `clippy::all = deny`, every new clippy release was a potential unreviewed CI break.

- `.mise.toml` — `rust = { version = "1.98.0", components = "clippy,rustfmt" }`; mise is now the single toolchain owner.
- `.github/actions/setup/action.yml` — dtolnay/rust-toolchain removed (it kept CI floating on rustup stable regardless of the mise pin); a provenance step prints which cargo/rustc/clippy resolved; hand-rolled cargo cache replaced with Swatinem/rust-cache, which keys on the actual rustc and doesn't cache `~/.cargo/bin` (now owned by mise's rust install).
- `.github/renovate.json` — the pin is excluded from automerge so every toolchain bump is a reviewed commit; without this, `group:allNonMajor` + `automerge: true` would auto-merge Rust minors and defeat the pin.
- `Cargo.toml` — `rust-version` raised 1.85 → 1.98.0: one supported version, floor == ceiling. The old floor was untested (no CI job built at 1.85) and protected nobody. Raising it unlocked clippy's MSRV-gated lints (`collapsible_if`, `manual_is_multiple_of`, `manual_as_chunks`); all source rewrites in this PR are machine-applied via `cargo clippy --fix` + `cargo fmt` — the reindentation of enclosing blocks is why the diff looks large.

## Verification

`mise install` provisions 1.98.0 with clippy 0.1.98 + rustfmt; `mise run check` and `mise run test` pass under the pin; actionlint clean on the composite action. CI's provenance step confirmed `cargo 1.98.0` resolves with dtolnay gone. Codex review verified the let-chain collapses preserve condition ordering and short-circuit behavior, and the `is_multiple_of`/`as_chunks` rewrites are equivalent under the existing divisibility checks.
