### PR TITLE
feat(core): implement emacs and basic copy-mode key tables

### DIFF
--- a/crates/oakterm-config/src/lib.rs
+++ b/crates/oakterm-config/src/lib.rs
@@ -24,8 +24,8 @@ pub use keybind::{
 pub use mlua::{self, Lua};
 pub use proxy::{extract_config, register_config_table};
 pub use schema::{
-    ConfigValues, CursorStyle, LeaderKey, Padding, StatusBarPosition, TextBlending, UpdateCheck,
-    WindowDecorations,
+    ConfigValues, CopyModePreset, CursorStyle, LeaderKey, Padding, StatusBarPosition, TextBlending,
+    UpdateCheck, WindowDecorations,
 };
 
 use mlua::{HookTriggers, LuaOptions, StdLib, Value, VmState};

--- a/crates/oakterm-config/src/proxy.rs
+++ b/crates/oakterm-config/src/proxy.rs
@@ -5,8 +5,8 @@
 use crate::event::{EVENT_REGISTRY_KEY, EventRegistry, KNOWN_EVENTS};
 use crate::keybind::{Action, KeyChord, KeybindRegistry};
 use crate::schema::{
-    self, ConfigValues, CursorStyle, Padding, StatusBarPosition, TextBlending, UpdateCheck,
-    WindowDecorations,
+    self, ConfigValues, CopyModePreset, CursorStyle, Padding, StatusBarPosition, TextBlending,
+    UpdateCheck, WindowDecorations,
 };
 use mlua::{Function, Lua, Table, Value};
 
@@ -694,6 +694,19 @@ pub fn extract_config(lua: &Lua) -> mlua::Result<ConfigValues> {
         None => defaults.status_bar_position,
     };
 
+    let copy_mode_keybinds = match backing.get::<Option<mlua::LuaString>>("copy_mode_keybinds")? {
+        Some(s) => {
+            let s = s.to_str()?;
+            CopyModePreset::from_config_str(&s).ok_or_else(|| {
+                mlua::Error::RuntimeError(format!(
+                    "invalid copy_mode_keybinds '{s}' (expected: {})",
+                    CopyModePreset::ALL.join(", ")
+                ))
+            })?
+        }
+        None => defaults.copy_mode_keybinds,
+    };
+
     let check_for_updates = match backing.get::<Option<mlua::LuaString>>("check_for_updates")? {
         Some(s) => {
             let s = s.to_str()?;
@@ -743,6 +756,7 @@ pub fn extract_config(lua: &Lua) -> mlua::Result<ConfigValues> {
         leader,
         status_bar,
         status_bar_position,
+        copy_mode_keybinds,
         check_for_updates,
         text_blending,
         text_gamma,
@@ -1224,6 +1238,40 @@ mod tests {
         assert!(err.is_err());
         let msg = err.unwrap_err().to_string();
         assert!(msg.contains("bottom, top"), "got: {msg}");
+    }
+
+    #[test]
+    fn copy_mode_keybinds_defaults_to_vim() {
+        let lua = setup();
+        let cfg = extract_config(&lua).unwrap();
+        assert_eq!(cfg.copy_mode_keybinds, CopyModePreset::Vim);
+    }
+
+    #[test]
+    fn set_copy_mode_keybinds() {
+        let lua = setup();
+        lua.load(r#"oakterm.config.copy_mode_keybinds = "emacs""#)
+            .exec()
+            .unwrap();
+        let cfg = extract_config(&lua).unwrap();
+        assert_eq!(cfg.copy_mode_keybinds, CopyModePreset::Emacs);
+
+        lua.load(r#"oakterm.config.copy_mode_keybinds = "basic""#)
+            .exec()
+            .unwrap();
+        let cfg = extract_config(&lua).unwrap();
+        assert_eq!(cfg.copy_mode_keybinds, CopyModePreset::Basic);
+    }
+
+    #[test]
+    fn set_invalid_copy_mode_keybinds() {
+        let lua = setup();
+        let err = lua
+            .load(r#"oakterm.config.copy_mode_keybinds = "kakoune""#)
+            .exec();
+        assert!(err.is_err());
+        let msg = err.unwrap_err().to_string();
+        assert!(msg.contains("vim, emacs, basic"), "got: {msg}");
     }
 
     #[test]

--- a/crates/oakterm-config/src/schema.rs
+++ b/crates/oakterm-config/src/schema.rs
@@ -162,6 +162,40 @@ impl StatusBarPosition {
     pub(crate) const ALL: &[&str] = &["bottom", "top"];
 }
 
+/// Copy-mode keybind preset (Spec-0008).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CopyModePreset {
+    #[default]
+    Vim,
+    Emacs,
+    Basic,
+}
+
+impl CopyModePreset {
+    /// Parse from a Lua config string.
+    #[must_use]
+    pub fn from_config_str(s: &str) -> Option<Self> {
+        match s {
+            "vim" => Some(Self::Vim),
+            "emacs" => Some(Self::Emacs),
+            "basic" => Some(Self::Basic),
+            _ => None,
+        }
+    }
+
+    /// Config string representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Vim => "vim",
+            Self::Emacs => "emacs",
+            Self::Basic => "basic",
+        }
+    }
+
+    pub(crate) const ALL: &[&str] = &["vim", "emacs", "basic"];
+}
+
 /// tmux-style leader key (ADR-0011): `oakterm.config.leader =
 /// { key = "ctrl+b", timeout = 1000 }`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -218,6 +252,7 @@ pub struct ConfigValues {
     pub leader: Option<LeaderKey>,
     pub status_bar: bool,
     pub status_bar_position: StatusBarPosition,
+    pub copy_mode_keybinds: CopyModePreset,
     pub check_for_updates: UpdateCheck,
     pub text_blending: TextBlending,
     /// Text gamma compensation exponent. Higher = thicker text.
@@ -246,6 +281,7 @@ impl Default for ConfigValues {
             leader: None,
             status_bar: true,
             status_bar_position: StatusBarPosition::default(),
+            copy_mode_keybinds: CopyModePreset::default(),
             check_for_updates: UpdateCheck::default(),
             text_blending: TextBlending::default(),
             text_gamma: if cfg!(target_os = "macos") { 1.7 } else { 1.0 },
@@ -352,6 +388,10 @@ pub(crate) static SCHEMA: &[ConfigKeyDef] = &[
     ConfigKeyDef {
         name: "status_bar_position",
         validate: validate_status_bar_position,
+    },
+    ConfigKeyDef {
+        name: "copy_mode_keybinds",
+        validate: validate_copy_mode_keybinds,
     },
     ConfigKeyDef {
         name: "check_for_updates",
@@ -542,6 +582,19 @@ fn validate_status_bar_position(_lua: &Lua, value: &Value) -> mlua::Result<()> {
             "invalid value '{}' (expected: {})",
             s,
             StatusBarPosition::ALL.join(", ")
+        )))
+    }
+}
+
+fn validate_copy_mode_keybinds(_lua: &Lua, value: &Value) -> mlua::Result<()> {
+    let s = as_str(value)?;
+    if CopyModePreset::from_config_str(&s).is_some() {
+        Ok(())
+    } else {
+        Err(mlua::Error::RuntimeError(format!(
+            "invalid value '{}' (expected: {})",
+            s,
+            CopyModePreset::ALL.join(", ")
         )))
     }
 }
@@ -762,6 +815,14 @@ mod tests {
     }
 
     #[test]
+    fn copy_mode_preset_round_trip() {
+        for s in CopyModePreset::ALL {
+            let preset = CopyModePreset::from_config_str(s).unwrap();
+            assert_eq!(preset.as_str(), *s);
+        }
+    }
+
+    #[test]
     fn window_decorations_round_trip() {
         for s in WindowDecorations::ALL {
             let d = WindowDecorations::from_config_str(s).unwrap();
@@ -790,7 +851,7 @@ mod tests {
         // Safety net: if a config key is added to ConfigValues, add it to SCHEMA too.
         assert_eq!(
             SCHEMA.len(),
-            21,
+            22,
             "SCHEMA must match ConfigValues field count"
         );
     }

--- a/crates/oakterm-config/src/stubs.rs
+++ b/crates/oakterm-config/src/stubs.rs
@@ -13,6 +13,7 @@ pub(crate) const OAKTERM_LUA_STUB: &str = r#"---@meta _
 ---@alias oakterm.WindowDecorations "full"|"none"
 ---@alias oakterm.UpdateCheck "off"|"check"
 ---@alias oakterm.StatusBarPosition "bottom"|"top"
+---@alias oakterm.CopyModeKeybinds "vim"|"emacs"|"basic"
 
 ---@class oakterm.Leader
 ---@field key string Leader chord (e.g. "ctrl+b")
@@ -150,6 +151,7 @@ function ActionModule.enter_copy_mode() end
 ---@field leader oakterm.Leader|nil tmux-style leader key for leader+... chords (default: nil)
 ---@field status_bar boolean Show the status bar (default: true)
 ---@field status_bar_position oakterm.StatusBarPosition Status bar edge (default: "bottom")
+---@field copy_mode_keybinds oakterm.CopyModeKeybinds Copy mode keybind preset (default: "vim")
 ---@field check_for_updates oakterm.UpdateCheck Update check policy (default: "off")
 ---@field text_blending oakterm.TextBlending Text blending mode for color accuracy (default: "linear_corrected")
 ---@field text_gamma number Text gamma compensation, higher = thicker text (default: 1.7 macOS, 1.0 Linux)
@@ -239,6 +241,7 @@ pub(crate) const CONFIG_TEMPLATE: &str = r#"-- OakTerm configuration
 -- oakterm.config.check_for_updates = "off"  -- "off", "check"
 
 -- Keybindings
+-- oakterm.config.copy_mode_keybinds = "vim" -- "vim", "emacs", "basic"
 -- oakterm.config.oak_mod = "ctrl+shift" -- modifier for oak_mod+... chords
 -- oakterm.config.leader = { key = "ctrl+b", timeout = 1000 } -- for leader+... chords
 -- oakterm.keybind("oak_mod+t", oakterm.action.new_tab())

--- a/crates/oakterm/src/copy_keys.rs
+++ b/crates/oakterm/src/copy_keys.rs
@@ -1,5 +1,5 @@
-//! The copy-mode key table (Spec-0008 vim preset): a key press in, a
-//! copy-mode command out.
+//! The copy-mode key tables (Spec-0008 vim, emacs, and basic presets):
+//! a key press in, a copy-mode command out.
 //!
 //! Copy mode resolves against the character the layout produced rather
 //! than a `KeyChord`, unlike every other dispatch layer. `$` is Shift+4
@@ -7,7 +7,8 @@
 //! character, so a chord built from the unmodified key would bind the
 //! wrong thing everywhere but one layout.
 
-use crate::copy_mode::CopySelectionType;
+use crate::copy_mode::{CopySelectionType, SelectionEffect};
+use oakterm_config::CopyModePreset;
 use winit::keyboard::{Key, ModifiersState, NamedKey};
 
 /// A key press as copy mode sees it.
@@ -16,9 +17,38 @@ pub(crate) enum CopyKey {
     /// The character the layout produced, no Ctrl/Alt/Super held.
     Char(char),
     /// Ctrl plus a base character, always lowercase; `copy_key` folds
-    /// case, and `ctrl_key` matches lowercase only.
+    /// case, and the tables match lowercase only.
     Ctrl(char),
+    /// Alt plus a character, case-folded: the composed character when it
+    /// is bindable, else the base key — macOS Option composes `ƒ` from
+    /// Alt+f, hiding the letter. `shift` lets a table catch `Alt+Shift+,`
+    /// as `Alt+<` when composition hid the shifted pair too; tables match
+    /// `..` on letters (shift-insensitive) and bind `shift: true` only
+    /// for that composition-recovery case.
+    Alt {
+        ch: char,
+        shift: bool,
+    },
+    /// A navigation key with its shift state; the basic preset binds
+    /// these, the others drop them.
+    Named {
+        key: NamedCopyKey,
+        shift: bool,
+    },
     Escape,
+}
+
+/// Navigation keys copy mode can classify.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NamedCopyKey {
+    Up,
+    Down,
+    Left,
+    Right,
+    PageUp,
+    PageDown,
+    Home,
+    End,
 }
 
 /// What one key press is to copy mode before the table sees it.
@@ -58,7 +88,13 @@ pub(crate) enum Motion {
 /// What a bound copy-mode key asks the GUI to do.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CopyCommand {
-    Move(Motion),
+    /// The selection effect rides on the motion so each table owns its
+    /// selection policy: vim and emacs keep, basic extends on shifted
+    /// navigation and clears on unshifted.
+    Move {
+        motion: Motion,
+        selection: SelectionEffect,
+    },
     ToggleSelection(CopySelectionType),
     /// Yank the selection and leave copy mode. A no-op without one.
     Yank,
@@ -98,13 +134,52 @@ pub(crate) fn copy_key(mods: ModifiersState, composed: &Key, base: &Key) -> Opti
     if matches!(composed, Key::Named(NamedKey::Escape)) {
         return Some(CopyKey::Escape);
     }
-    if mods.super_key() || mods.alt_key() {
+    if mods.super_key() {
         return None;
+    }
+    let shift = mods.shift_key();
+    if mods.alt_key() {
+        if mods.control_key() {
+            return None;
+        }
+        return alt_char(composed, base).map(|ch| CopyKey::Alt { ch, shift });
     }
     if mods.control_key() {
         return single_char(base).map(|c| CopyKey::Ctrl(c.to_ascii_lowercase()));
     }
+    if let Some(key) = named_copy_key(composed) {
+        return Some(CopyKey::Named { key, shift });
+    }
     single_char(composed).map(CopyKey::Char)
+}
+
+/// The character an Alt chord binds: the composed character when the
+/// layout produced a plain ASCII one, else the base key. macOS Option
+/// composes symbols (`ƒ` from Alt+f), so the base is the only usable
+/// name there; everywhere else the composed character carries shifted
+/// pairs like `<` that the base key cannot.
+fn alt_char(composed: &Key, base: &Key) -> Option<char> {
+    single_char(composed)
+        .filter(char::is_ascii_graphic)
+        .or_else(|| single_char(base))
+        .map(|c| c.to_ascii_lowercase())
+}
+
+fn named_copy_key(key: &Key) -> Option<NamedCopyKey> {
+    let Key::Named(named) = key else {
+        return None;
+    };
+    match named {
+        NamedKey::ArrowUp => Some(NamedCopyKey::Up),
+        NamedKey::ArrowDown => Some(NamedCopyKey::Down),
+        NamedKey::ArrowLeft => Some(NamedCopyKey::Left),
+        NamedKey::ArrowRight => Some(NamedCopyKey::Right),
+        NamedKey::PageUp => Some(NamedCopyKey::PageUp),
+        NamedKey::PageDown => Some(NamedCopyKey::PageDown),
+        NamedKey::Home => Some(NamedCopyKey::Home),
+        NamedKey::End => Some(NamedCopyKey::End),
+        _ => None,
+    }
 }
 
 /// Classify a key press, separating a bare modifier keydown from a key
@@ -115,6 +190,14 @@ pub(crate) fn copy_press(mods: ModifiersState, composed: &Key, base: &Key) -> Co
         return CopyPress::ModifierOnly;
     }
     copy_key(mods, composed, base).map_or(CopyPress::Unnameable, CopyPress::Key)
+}
+
+/// Movement that leaves the selection alone — every vim and emacs row.
+fn mv(motion: Motion) -> CopyCommand {
+    CopyCommand::Move {
+        motion,
+        selection: SelectionEffect::Keep,
+    }
 }
 
 /// Whether the key is a modifier pressed on its own.
@@ -142,26 +225,34 @@ fn is_modifier(key: &Key) -> bool {
 
 /// Advance the pending-prefix state machine by one press: the prefix to
 /// hold afterwards, and the command to run if the press completed one.
+/// Only the vim preset has multi-key sequences; the other tables resolve
+/// every press on its own and clear any prefix a preset switch left.
 pub(crate) fn advance_copy_key(
+    preset: CopyModePreset,
     pending: Option<PendingPrefix>,
     press: CopyPress,
 ) -> (Option<PendingPrefix>, Option<CopyCommand>) {
     match press {
         CopyPress::ModifierOnly => (pending, None),
         CopyPress::Unnameable => (None, None),
-        CopyPress::Key(key) => match vim_key(pending, key) {
-            VimKey::Pending(prefix) => (Some(prefix), None),
-            VimKey::Run(command) => (None, Some(command)),
-            VimKey::Drop => (None, None),
+        CopyPress::Key(key) => match preset {
+            CopyModePreset::Vim => match vim_key(pending, key) {
+                VimKey::Pending(prefix) => (Some(prefix), None),
+                VimKey::Run(command) => (None, Some(command)),
+                VimKey::Drop => (None, None),
+            },
+            CopyModePreset::Emacs => (None, emacs_key(key)),
+            CopyModePreset::Basic => (None, basic_key(key)),
         },
     }
 }
 
 /// The character of a single-character key, or `None` for named keys and
-/// multi-character IME composition.
+/// multi-character IME composition. Space is a named key in winit but a
+/// character to the tables — emacs binds Ctrl+Space.
 fn single_char(key: &Key) -> Option<char> {
     let Key::Character(text) = key else {
-        return None;
+        return matches!(key, Key::Named(NamedKey::Space)).then_some(' ');
     };
     let mut chars = text.chars();
     let first = chars.next()?;
@@ -177,7 +268,7 @@ fn single_char(key: &Key) -> Option<char> {
 pub(crate) fn vim_key(pending: Option<PendingPrefix>, key: CopyKey) -> VimKey {
     if pending == Some(PendingPrefix::G) {
         return if key == CopyKey::Char('g') {
-            VimKey::Run(CopyCommand::Move(Motion::Top))
+            VimKey::Run(mv(Motion::Top))
         } else {
             VimKey::Drop
         };
@@ -186,24 +277,93 @@ pub(crate) fn vim_key(pending: Option<PendingPrefix>, key: CopyKey) -> VimKey {
         CopyKey::Char(c) => char_key(c),
         CopyKey::Ctrl(c) => ctrl_key(c),
         CopyKey::Escape => VimKey::Run(CopyCommand::ClearOrExit),
+        CopyKey::Alt { .. } | CopyKey::Named { .. } => VimKey::Drop,
+    }
+}
+
+/// Resolve one key against the emacs preset (Spec-0008). `None` drops
+/// the key; copy mode is modal in every preset.
+pub(crate) fn emacs_key(key: CopyKey) -> Option<CopyCommand> {
+    use CopyCommand::{ClearOrExit, Exit, Search, ToggleSelection, Yank};
+    match key {
+        CopyKey::Ctrl('n') => Some(mv(Motion::Down)),
+        CopyKey::Ctrl('p') => Some(mv(Motion::Up)),
+        CopyKey::Ctrl('f') => Some(mv(Motion::Right)),
+        CopyKey::Ctrl('b') => Some(mv(Motion::Left)),
+        CopyKey::Ctrl('a') => Some(mv(Motion::LineStart)),
+        CopyKey::Ctrl('e') => Some(mv(Motion::LineEnd)),
+        CopyKey::Ctrl('v') => Some(mv(Motion::PageDown)),
+        CopyKey::Ctrl(' ') => Some(ToggleSelection(CopySelectionType::Character)),
+        CopyKey::Ctrl('g') => Some(Exit),
+        CopyKey::Ctrl('s' | 'r') => Some(Search),
+        CopyKey::Alt { ch: 'f', .. } => Some(mv(Motion::WordEnd)),
+        CopyKey::Alt { ch: 'b', .. } => Some(mv(Motion::WordBackward)),
+        CopyKey::Alt { ch: 'v', .. } => Some(mv(Motion::PageUp)),
+        CopyKey::Alt { ch: 'w', .. } => Some(Yank),
+        // `Alt+Shift+,` and `Alt+Shift+.` are `M-<`/`M->` on layouts
+        // where Option composition hid the shifted character.
+        CopyKey::Alt { ch: '<', .. }
+        | CopyKey::Alt {
+            ch: ',',
+            shift: true,
+        } => Some(mv(Motion::Top)),
+        CopyKey::Alt { ch: '>', .. }
+        | CopyKey::Alt {
+            ch: '.',
+            shift: true,
+        } => Some(mv(Motion::Bottom)),
+        CopyKey::Escape => Some(ClearOrExit),
+        _ => None,
+    }
+}
+
+/// Resolve one key against the basic preset (Spec-0008): shifted
+/// navigation extends the selection, unshifted navigation clears it.
+pub(crate) fn basic_key(key: CopyKey) -> Option<CopyCommand> {
+    use CopyCommand::{ClearOrExit, Move, Search, Yank};
+    match key {
+        CopyKey::Named { key, shift } => {
+            let motion = match key {
+                NamedCopyKey::Up => Motion::Up,
+                NamedCopyKey::Down => Motion::Down,
+                NamedCopyKey::Left => Motion::Left,
+                NamedCopyKey::Right => Motion::Right,
+                NamedCopyKey::PageUp => Motion::PageUp,
+                NamedCopyKey::PageDown => Motion::PageDown,
+                NamedCopyKey::Home => Motion::Top,
+                NamedCopyKey::End => Motion::Bottom,
+            };
+            let selection = if shift {
+                SelectionEffect::Extend
+            } else {
+                SelectionEffect::Clear
+            };
+            Some(Move { motion, selection })
+        }
+        CopyKey::Ctrl('c') => Some(Yank),
+        CopyKey::Ctrl('f') => Some(Search),
+        // Clear-then-exit: no toggle key exists here, so Escape is the
+        // only cancel a Shift+arrow selection has.
+        CopyKey::Escape => Some(ClearOrExit),
+        _ => None,
     }
 }
 
 fn char_key(c: char) -> VimKey {
-    use CopyCommand::{Exit, Move, Search, ToggleSelection, Yank};
+    use CopyCommand::{Exit, Search, ToggleSelection, Yank};
     match c {
-        'h' => VimKey::Run(Move(Motion::Left)),
-        'j' => VimKey::Run(Move(Motion::Down)),
-        'k' => VimKey::Run(Move(Motion::Up)),
-        'l' => VimKey::Run(Move(Motion::Right)),
-        'w' => VimKey::Run(Move(Motion::WordForward)),
-        'b' => VimKey::Run(Move(Motion::WordBackward)),
-        'e' => VimKey::Run(Move(Motion::WordEnd)),
-        '0' => VimKey::Run(Move(Motion::LineStart)),
-        '$' => VimKey::Run(Move(Motion::LineEnd)),
-        '^' => VimKey::Run(Move(Motion::FirstNonBlank)),
+        'h' => VimKey::Run(mv(Motion::Left)),
+        'j' => VimKey::Run(mv(Motion::Down)),
+        'k' => VimKey::Run(mv(Motion::Up)),
+        'l' => VimKey::Run(mv(Motion::Right)),
+        'w' => VimKey::Run(mv(Motion::WordForward)),
+        'b' => VimKey::Run(mv(Motion::WordBackward)),
+        'e' => VimKey::Run(mv(Motion::WordEnd)),
+        '0' => VimKey::Run(mv(Motion::LineStart)),
+        '$' => VimKey::Run(mv(Motion::LineEnd)),
+        '^' => VimKey::Run(mv(Motion::FirstNonBlank)),
         'g' => VimKey::Pending(PendingPrefix::G),
-        'G' => VimKey::Run(Move(Motion::Bottom)),
+        'G' => VimKey::Run(mv(Motion::Bottom)),
         'v' => VimKey::Run(ToggleSelection(CopySelectionType::Character)),
         'V' => VimKey::Run(ToggleSelection(CopySelectionType::Line)),
         'y' => VimKey::Run(Yank),
@@ -214,12 +374,12 @@ fn char_key(c: char) -> VimKey {
 }
 
 fn ctrl_key(c: char) -> VimKey {
-    use CopyCommand::{Move, ToggleSelection};
+    use CopyCommand::ToggleSelection;
     match c {
-        'd' => VimKey::Run(Move(Motion::HalfPageDown)),
-        'u' => VimKey::Run(Move(Motion::HalfPageUp)),
-        'f' => VimKey::Run(Move(Motion::PageDown)),
-        'b' => VimKey::Run(Move(Motion::PageUp)),
+        'd' => VimKey::Run(mv(Motion::HalfPageDown)),
+        'u' => VimKey::Run(mv(Motion::HalfPageUp)),
+        'f' => VimKey::Run(mv(Motion::PageDown)),
+        'b' => VimKey::Run(mv(Motion::PageUp)),
         'v' => VimKey::Run(ToggleSelection(CopySelectionType::Block)),
         _ => VimKey::Drop,
     }
@@ -228,10 +388,11 @@ fn ctrl_key(c: char) -> VimKey {
 #[cfg(test)]
 mod tests {
     use super::{
-        CopyCommand, CopyKey, CopyPress, Motion, PendingPrefix, VimKey, advance_copy_key, copy_key,
-        copy_press, vim_key,
+        CopyCommand, CopyKey, CopyPress, Motion, NamedCopyKey, PendingPrefix, VimKey,
+        advance_copy_key, basic_key, copy_key, copy_press, emacs_key, mv, vim_key,
     };
-    use crate::copy_mode::CopySelectionType;
+    use crate::copy_mode::{CopySelectionType, SelectionEffect};
+    use oakterm_config::CopyModePreset;
     use winit::keyboard::{Key, ModifiersState, NamedKey};
 
     fn ch(c: char) -> Key {
@@ -244,23 +405,23 @@ mod tests {
 
     #[test]
     fn the_vim_preset_binds_every_row_of_the_spec_table() {
-        use CopyCommand::{Move, Search, ToggleSelection, Yank};
+        use CopyCommand::{Search, ToggleSelection, Yank};
         let cases = [
-            (CopyKey::Char('h'), Move(Motion::Left)),
-            (CopyKey::Char('j'), Move(Motion::Down)),
-            (CopyKey::Char('k'), Move(Motion::Up)),
-            (CopyKey::Char('l'), Move(Motion::Right)),
-            (CopyKey::Char('w'), Move(Motion::WordForward)),
-            (CopyKey::Char('b'), Move(Motion::WordBackward)),
-            (CopyKey::Char('e'), Move(Motion::WordEnd)),
-            (CopyKey::Char('0'), Move(Motion::LineStart)),
-            (CopyKey::Char('$'), Move(Motion::LineEnd)),
-            (CopyKey::Char('^'), Move(Motion::FirstNonBlank)),
-            (CopyKey::Char('G'), Move(Motion::Bottom)),
-            (CopyKey::Ctrl('d'), Move(Motion::HalfPageDown)),
-            (CopyKey::Ctrl('u'), Move(Motion::HalfPageUp)),
-            (CopyKey::Ctrl('f'), Move(Motion::PageDown)),
-            (CopyKey::Ctrl('b'), Move(Motion::PageUp)),
+            (CopyKey::Char('h'), mv(Motion::Left)),
+            (CopyKey::Char('j'), mv(Motion::Down)),
+            (CopyKey::Char('k'), mv(Motion::Up)),
+            (CopyKey::Char('l'), mv(Motion::Right)),
+            (CopyKey::Char('w'), mv(Motion::WordForward)),
+            (CopyKey::Char('b'), mv(Motion::WordBackward)),
+            (CopyKey::Char('e'), mv(Motion::WordEnd)),
+            (CopyKey::Char('0'), mv(Motion::LineStart)),
+            (CopyKey::Char('$'), mv(Motion::LineEnd)),
+            (CopyKey::Char('^'), mv(Motion::FirstNonBlank)),
+            (CopyKey::Char('G'), mv(Motion::Bottom)),
+            (CopyKey::Ctrl('d'), mv(Motion::HalfPageDown)),
+            (CopyKey::Ctrl('u'), mv(Motion::HalfPageUp)),
+            (CopyKey::Ctrl('f'), mv(Motion::PageDown)),
+            (CopyKey::Ctrl('b'), mv(Motion::PageUp)),
             (
                 CopyKey::Char('v'),
                 ToggleSelection(CopySelectionType::Character),
@@ -290,10 +451,7 @@ mod tests {
     fn shifted_letters_are_distinct_bindings() {
         assert_ne!(run(CopyKey::Char('v')), run(CopyKey::Char('V')));
         assert_eq!(run(CopyKey::Char('g')), VimKey::Pending(PendingPrefix::G));
-        assert_eq!(
-            run(CopyKey::Char('G')),
-            VimKey::Run(CopyCommand::Move(Motion::Bottom))
-        );
+        assert_eq!(run(CopyKey::Char('G')), VimKey::Run(mv(Motion::Bottom)));
     }
 
     /// Copy mode is modal: an unbound key is consumed, never forwarded.
@@ -317,7 +475,7 @@ mod tests {
         );
         assert_eq!(
             vim_key(Some(PendingPrefix::G), CopyKey::Char('g')),
-            VimKey::Run(CopyCommand::Move(Motion::Top))
+            VimKey::Run(mv(Motion::Top))
         );
     }
 
@@ -351,10 +509,7 @@ mod tests {
             (CopyKey::Char('g'), VimKey::Pending(PendingPrefix::G)),
             (CopyKey::Char('j'), VimKey::Drop),
             (CopyKey::Char('g'), VimKey::Pending(PendingPrefix::G)),
-            (
-                CopyKey::Char('g'),
-                VimKey::Run(CopyCommand::Move(Motion::Top)),
-            ),
+            (CopyKey::Char('g'), VimKey::Run(mv(Motion::Top))),
         ] {
             let outcome = vim_key(pending, key);
             assert_eq!(outcome, expected, "{key:?}");
@@ -375,23 +530,24 @@ mod tests {
     /// fire the sequence, and the two ways one gets interrupted.
     #[test]
     fn advancing_the_prefix_arms_fires_and_interrupts() {
+        let vim = CopyModePreset::Vim;
         assert_eq!(
-            advance_copy_key(None, key('g')),
+            advance_copy_key(vim, None, key('g')),
             (Some(PendingPrefix::G), None),
             "arm"
         );
         assert_eq!(
-            advance_copy_key(Some(PendingPrefix::G), key('g')),
-            (None, Some(CopyCommand::Move(Motion::Top))),
+            advance_copy_key(vim, Some(PendingPrefix::G), key('g')),
+            (None, Some(mv(Motion::Top))),
             "fire"
         );
         assert_eq!(
-            advance_copy_key(Some(PendingPrefix::G), key('j')),
+            advance_copy_key(vim, Some(PendingPrefix::G), key('j')),
             (None, None),
             "a bound key interrupts without running"
         );
         assert_eq!(
-            advance_copy_key(Some(PendingPrefix::G), CopyPress::Unnameable),
+            advance_copy_key(vim, Some(PendingPrefix::G), CopyPress::Unnameable),
             (None, None),
             "a key the preset cannot name interrupts too"
         );
@@ -402,25 +558,23 @@ mod tests {
     /// unable to reach anything shifted.
     #[test]
     fn a_bare_modifier_press_leaves_a_pending_prefix_armed() {
+        let vim = CopyModePreset::Vim;
         let shift = Key::Named(NamedKey::Shift);
         let press = copy_press(ModifiersState::SHIFT, &shift, &shift);
         assert_eq!(press, CopyPress::ModifierOnly);
 
-        let (pending, command) = advance_copy_key(None, key('g'));
+        let (pending, command) = advance_copy_key(vim, None, key('g'));
         assert_eq!((pending, command), (Some(PendingPrefix::G), None));
 
-        let (pending, command) = advance_copy_key(pending, press);
+        let (pending, command) = advance_copy_key(vim, pending, press);
         assert_eq!(
             (pending, command),
             (Some(PendingPrefix::G), None),
             "the modifier is not a key of the sequence"
         );
 
-        let (pending, command) = advance_copy_key(pending, key('g'));
-        assert_eq!(
-            (pending, command),
-            (None, Some(CopyCommand::Move(Motion::Top)))
-        );
+        let (pending, command) = advance_copy_key(vim, pending, key('g'));
+        assert_eq!((pending, command), (None, Some(mv(Motion::Top))));
     }
 
     /// Only modifiers get that treatment: an ordinary named key is
@@ -490,16 +644,110 @@ mod tests {
         }
     }
 
-    /// Super and Alt chords resolve to nothing, so the caller drops them
-    /// rather than reading `Cmd+T` as a bare `t`.
+    /// Super chords resolve to nothing, so the caller drops them rather
+    /// than reading `Cmd+T` as a bare `t`. Ctrl+Alt binds nothing in any
+    /// preset and resolves to nothing too.
     #[test]
-    fn super_and_alt_chords_resolve_to_no_copy_key() {
+    fn super_and_ctrl_alt_chords_resolve_to_no_copy_key() {
         assert_eq!(copy_key(ModifiersState::SUPER, &ch('t'), &ch('t')), None);
-        assert_eq!(copy_key(ModifiersState::ALT, &ch('f'), &ch('f')), None);
+        assert_eq!(
+            copy_key(
+                ModifiersState::CONTROL | ModifiersState::ALT,
+                &ch('f'),
+                &ch('f')
+            ),
+            None
+        );
     }
 
-    /// Named keys other than Escape and multi-character IME composition
-    /// bind nothing in the vim preset.
+    /// Alt chords read the composed character when it is plain ASCII
+    /// (Linux, Windows) and fall back to the base key when Option
+    /// composed a symbol (macOS).
+    #[test]
+    fn alt_chords_prefer_the_composed_character_and_fall_back_to_base() {
+        assert_eq!(
+            copy_key(ModifiersState::ALT, &ch('f'), &ch('f')),
+            Some(CopyKey::Alt {
+                ch: 'f',
+                shift: false
+            })
+        );
+        assert_eq!(
+            copy_key(ModifiersState::ALT, &ch('ƒ'), &ch('f')),
+            Some(CopyKey::Alt {
+                ch: 'f',
+                shift: false
+            }),
+            "macOS Option composition falls back to the base key"
+        );
+        assert_eq!(
+            copy_key(
+                ModifiersState::ALT | ModifiersState::SHIFT,
+                &ch('<'),
+                &ch(',')
+            ),
+            Some(CopyKey::Alt {
+                ch: '<',
+                shift: true
+            }),
+            "a composed shifted pair carries the character"
+        );
+        assert_eq!(
+            copy_key(
+                ModifiersState::ALT | ModifiersState::SHIFT,
+                &ch('¯'),
+                &ch(',')
+            ),
+            Some(CopyKey::Alt {
+                ch: ',',
+                shift: true
+            }),
+            "composition hiding the pair leaves base + shift"
+        );
+    }
+
+    /// Arrows and the other navigation keys classify with their shift
+    /// state; the basic preset needs both.
+    #[test]
+    fn navigation_keys_classify_with_shift_state() {
+        let up = Key::Named(NamedKey::ArrowUp);
+        assert_eq!(
+            copy_key(ModifiersState::empty(), &up, &up),
+            Some(CopyKey::Named {
+                key: NamedCopyKey::Up,
+                shift: false
+            })
+        );
+        assert_eq!(
+            copy_key(ModifiersState::SHIFT, &up, &up),
+            Some(CopyKey::Named {
+                key: NamedCopyKey::Up,
+                shift: true
+            })
+        );
+        let home = Key::Named(NamedKey::Home);
+        assert_eq!(
+            copy_key(ModifiersState::empty(), &home, &home),
+            Some(CopyKey::Named {
+                key: NamedCopyKey::Home,
+                shift: false
+            })
+        );
+    }
+
+    /// Ctrl+Space must classify: emacs binds it to start a selection.
+    /// winit names Space rather than composing it to a character.
+    #[test]
+    fn ctrl_space_classifies_for_the_emacs_preset() {
+        let space = Key::Named(NamedKey::Space);
+        assert_eq!(
+            copy_key(ModifiersState::CONTROL, &space, &space),
+            Some(CopyKey::Ctrl(' '))
+        );
+    }
+
+    /// Named keys outside the navigation set and multi-character IME
+    /// composition bind nothing in any preset.
     #[test]
     fn named_keys_and_ime_composition_resolve_to_no_copy_key() {
         let none = ModifiersState::empty();
@@ -507,5 +755,192 @@ mod tests {
         assert_eq!(copy_key(none, &tab, &tab), None);
         let ime = Key::Character("ab".into());
         assert_eq!(copy_key(none, &ime, &ime), None);
+    }
+
+    // --- Emacs preset ---
+
+    fn alt(ch: char) -> CopyKey {
+        CopyKey::Alt { ch, shift: false }
+    }
+
+    #[test]
+    fn the_emacs_preset_binds_every_row_of_the_spec_table() {
+        use CopyCommand::{Exit, Search, ToggleSelection, Yank};
+        let cases = [
+            (CopyKey::Ctrl('n'), mv(Motion::Down)),
+            (CopyKey::Ctrl('p'), mv(Motion::Up)),
+            (CopyKey::Ctrl('f'), mv(Motion::Right)),
+            (CopyKey::Ctrl('b'), mv(Motion::Left)),
+            (alt('f'), mv(Motion::WordEnd)),
+            (alt('b'), mv(Motion::WordBackward)),
+            (CopyKey::Ctrl('a'), mv(Motion::LineStart)),
+            (CopyKey::Ctrl('e'), mv(Motion::LineEnd)),
+            (alt('<'), mv(Motion::Top)),
+            (alt('>'), mv(Motion::Bottom)),
+            (CopyKey::Ctrl('v'), mv(Motion::PageDown)),
+            (alt('v'), mv(Motion::PageUp)),
+            (
+                CopyKey::Ctrl(' '),
+                ToggleSelection(CopySelectionType::Character),
+            ),
+            (alt('w'), Yank),
+            (CopyKey::Ctrl('g'), Exit),
+            (CopyKey::Ctrl('s'), Search),
+            (CopyKey::Ctrl('r'), Search),
+            (CopyKey::Escape, CopyCommand::ClearOrExit),
+        ];
+        for (key, expected) in cases {
+            assert_eq!(emacs_key(key), Some(expected), "{key:?}");
+        }
+    }
+
+    /// `M-<`/`M->` reach the buffer ends even when Option composition
+    /// hid the shifted pair and classification fell back to the base.
+    #[test]
+    fn emacs_buffer_ends_survive_macos_option_composition() {
+        assert_eq!(
+            emacs_key(CopyKey::Alt {
+                ch: ',',
+                shift: true
+            }),
+            Some(mv(Motion::Top))
+        );
+        assert_eq!(
+            emacs_key(CopyKey::Alt {
+                ch: '.',
+                shift: true
+            }),
+            Some(mv(Motion::Bottom))
+        );
+        assert_eq!(emacs_key(alt(',')), None, "unshifted comma stays unbound");
+        assert_eq!(emacs_key(alt('.')), None, "unshifted period stays unbound");
+    }
+
+    /// Emacs is modal too: keys the preset does not bind are dropped,
+    /// including everything the vim preset would run.
+    #[test]
+    fn emacs_drops_unbound_keys() {
+        for key in [
+            CopyKey::Char('j'),
+            CopyKey::Char('y'),
+            CopyKey::Char('q'),
+            CopyKey::Ctrl('c'),
+            CopyKey::Named {
+                key: NamedCopyKey::Up,
+                shift: false,
+            },
+        ] {
+            assert_eq!(emacs_key(key), None, "{key:?}");
+        }
+    }
+
+    // --- Basic preset ---
+
+    fn named(key: NamedCopyKey, shift: bool) -> CopyKey {
+        CopyKey::Named { key, shift }
+    }
+
+    fn clearing(motion: Motion) -> CopyCommand {
+        CopyCommand::Move {
+            motion,
+            selection: SelectionEffect::Clear,
+        }
+    }
+
+    fn extending(motion: Motion) -> CopyCommand {
+        CopyCommand::Move {
+            motion,
+            selection: SelectionEffect::Extend,
+        }
+    }
+
+    #[test]
+    fn the_basic_preset_binds_every_row_of_the_spec_table() {
+        use CopyCommand::{ClearOrExit, Search, Yank};
+        use NamedCopyKey::{Down, End, Home, Left, PageDown, PageUp, Right, Up};
+        let cases = [
+            (named(Up, false), clearing(Motion::Up)),
+            (named(Down, false), clearing(Motion::Down)),
+            (named(Left, false), clearing(Motion::Left)),
+            (named(Right, false), clearing(Motion::Right)),
+            (named(PageUp, false), clearing(Motion::PageUp)),
+            (named(PageDown, false), clearing(Motion::PageDown)),
+            (named(Home, false), clearing(Motion::Top)),
+            (named(End, false), clearing(Motion::Bottom)),
+            (named(Up, true), extending(Motion::Up)),
+            (named(Down, true), extending(Motion::Down)),
+            (named(Left, true), extending(Motion::Left)),
+            (named(Right, true), extending(Motion::Right)),
+            (CopyKey::Ctrl('c'), Yank),
+            (CopyKey::Ctrl('f'), Search),
+            (CopyKey::Escape, ClearOrExit),
+        ];
+        for (key, expected) in cases {
+            assert_eq!(basic_key(key), Some(expected), "{key:?}");
+        }
+    }
+
+    /// Shifted paging extends like shifted arrows do: GUI convention
+    /// anchors on any Shift+navigation, not just arrows.
+    #[test]
+    fn basic_shifted_paging_extends_the_selection_too() {
+        use NamedCopyKey::{End, Home, PageDown, PageUp};
+        for (key, motion) in [
+            (PageUp, Motion::PageUp),
+            (PageDown, Motion::PageDown),
+            (Home, Motion::Top),
+            (End, Motion::Bottom),
+        ] {
+            assert_eq!(
+                basic_key(named(key, true)),
+                Some(extending(motion)),
+                "{key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn basic_drops_unbound_keys() {
+        for key in [
+            CopyKey::Char('j'),
+            CopyKey::Char('y'),
+            CopyKey::Char('q'),
+            CopyKey::Ctrl('g'),
+            alt('w'),
+        ] {
+            assert_eq!(basic_key(key), None, "{key:?}");
+        }
+    }
+
+    /// The non-vim presets have no multi-key sequences, so a prefix a
+    /// preset switch left behind clears instead of haunting dispatch.
+    #[test]
+    fn non_vim_presets_clear_a_leftover_prefix() {
+        for preset in [CopyModePreset::Emacs, CopyModePreset::Basic] {
+            assert_eq!(
+                advance_copy_key(preset, Some(PendingPrefix::G), key('g')),
+                (None, None),
+                "{preset:?}"
+            );
+        }
+    }
+
+    /// Each preset routes to its own table: `Ctrl+f` means something
+    /// different in all three, so a swapped dispatch arm cannot pass.
+    #[test]
+    fn advance_routes_each_preset_to_its_own_table() {
+        let ctrl_f = CopyPress::Key(CopyKey::Ctrl('f'));
+        assert_eq!(
+            advance_copy_key(CopyModePreset::Vim, None, ctrl_f),
+            (None, Some(mv(Motion::PageDown)))
+        );
+        assert_eq!(
+            advance_copy_key(CopyModePreset::Emacs, None, ctrl_f),
+            (None, Some(mv(Motion::Right)))
+        );
+        assert_eq!(
+            advance_copy_key(CopyModePreset::Basic, None, ctrl_f),
+            (None, Some(CopyCommand::Search))
+        );
     }
 }

--- a/crates/oakterm/src/copy_mode.rs
+++ b/crates/oakterm/src/copy_mode.rs
@@ -22,6 +22,16 @@ use tracing::warn;
 /// beside it would only add a conversion that can drift.
 pub(crate) use oakterm_protocol::message::CopySelectionType;
 
+/// What a motion does to the selection, carried on the command so the
+/// preset tables own the policy and the dispatcher stays exhaustive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectionEffect {
+    Keep,
+    /// Anchor a character selection at the cursor if none is active.
+    Extend,
+    Clear,
+}
+
 /// Per-request row cap the daemon enforces (Spec-0001 `GetScrollback`).
 const MAX_ROWS_PER_REQUEST: u32 = 4096;
 
@@ -353,14 +363,29 @@ impl CopyModeState {
                     selection.ty = ty;
                 }
             }
-            None => {
-                self.selection = Some(CopySelection {
-                    ty,
-                    anchor_row: self.cursor_row,
-                    anchor_col: self.cursor_col,
-                });
-            }
+            None => self.anchor_selection(ty),
         }
+    }
+
+    /// Apply a motion's selection effect before the cursor moves.
+    pub(crate) fn apply_selection_effect(&mut self, effect: SelectionEffect) {
+        match effect {
+            SelectionEffect::Keep => {}
+            SelectionEffect::Extend => {
+                if self.selection.is_none() {
+                    self.anchor_selection(CopySelectionType::Character);
+                }
+            }
+            SelectionEffect::Clear => self.selection = None,
+        }
+    }
+
+    fn anchor_selection(&mut self, ty: CopySelectionType) {
+        self.selection = Some(CopySelection {
+            ty,
+            anchor_row: self.cursor_row,
+            anchor_col: self.cursor_col,
+        });
     }
 
     /// Drop the selection, reporting whether there was one. Escape uses
@@ -527,7 +552,8 @@ impl CopyModeState {
 #[cfg(test)]
 mod tests {
     use super::{
-        CopyModeState, CopySelectionType, FillFailure, FillRequest, ViewportCache, YankRange,
+        CopyModeState, CopySelectionType, FillFailure, FillRequest, SelectionEffect, ViewportCache,
+        YankRange,
     };
     use oakterm_protocol::message::ScrollbackData;
     use oakterm_protocol::render::{DirtyRow, WireCell};
@@ -1128,6 +1154,44 @@ mod tests {
         state.toggle_selection(CopySelectionType::Character);
         let range = state.yank_range().expect("a fresh selection");
         assert_eq!((range.start_row, range.start_col), (2, 7));
+    }
+
+    /// Shift+arrow in the basic preset extends before each move: the
+    /// first press anchors, later presses must not re-anchor.
+    #[test]
+    fn extend_anchors_once_and_keeps_the_anchor_after() {
+        let mut state = CopyModeState::new(80, 8, 0);
+        state.set_cursor(2, 3);
+
+        state.apply_selection_effect(SelectionEffect::Extend);
+        state.set_cursor(4, 6);
+        state.apply_selection_effect(SelectionEffect::Extend);
+
+        let range = state.yank_range().expect("selecting");
+        assert_eq!(range.ty, CopySelectionType::Character);
+        assert_eq!(
+            (range.start_row, range.start_col),
+            (2, 3),
+            "the second extend keeps the original anchor"
+        );
+        assert_eq!((range.end_row, range.end_col), (4, 6));
+    }
+
+    /// The three effects in one pass: keep leaves a selection alone,
+    /// clear drops it, and keep never anchors one.
+    #[test]
+    fn keep_and_clear_effects_leave_and_drop_the_selection() {
+        let mut state = CopyModeState::new(80, 8, 0);
+
+        state.apply_selection_effect(SelectionEffect::Keep);
+        assert_eq!(state.yank_range(), None, "keep never anchors");
+
+        state.apply_selection_effect(SelectionEffect::Extend);
+        state.apply_selection_effect(SelectionEffect::Keep);
+        assert!(state.yank_range().is_some(), "keep leaves it alone");
+
+        state.apply_selection_effect(SelectionEffect::Clear);
+        assert_eq!(state.yank_range(), None);
     }
 
     #[test]

--- a/crates/oakterm/src/main.rs
+++ b/crates/oakterm/src/main.rs
@@ -973,7 +973,8 @@ impl App {
             .panes
             .get(&pane_id)
             .and_then(PaneView::copy_mode_pending_prefix);
-        let (next, command) = copy_keys::advance_copy_key(pending, press);
+        let (next, command) =
+            copy_keys::advance_copy_key(self.config.copy_mode_keybinds, pending, press);
         if pending != next
             && let Some(view) = self.panes.get_mut(&pane_id)
         {
@@ -992,9 +993,9 @@ impl App {
     fn run_copy_mode_command(&mut self, pane_id: u32, command: copy_keys::CopyCommand) {
         use copy_keys::CopyCommand;
         match command {
-            CopyCommand::Move(motion) => {
+            CopyCommand::Move { motion, selection } => {
                 if let Some(view) = self.panes.get_mut(&pane_id) {
-                    view.move_copy_mode_cursor(motion);
+                    view.move_copy_mode_cursor(motion, selection);
                 }
                 // Spec-0008 prefetches on the cursor entering the edge
                 // quarter of the cache, not only after a fill lands.

--- a/crates/oakterm/src/pane_view.rs
+++ b/crates/oakterm/src/pane_view.rs
@@ -4,7 +4,8 @@
 
 use crate::copy_keys::{Motion, PendingPrefix};
 use crate::copy_mode::{
-    CopyModeState, CopySelectionType, FillFailure, FillRequest, ViewportCache, YankRange,
+    CopyModeState, CopySelectionType, FillFailure, FillRequest, SelectionEffect, ViewportCache,
+    YankRange,
 };
 use crate::copy_motion::{RowText, resolve};
 use crate::render_grid::ClientGrid;
@@ -281,11 +282,15 @@ impl PaneView {
     }
 
     /// Apply a copy-mode motion, resolved against the cached scrollback
-    /// rows and the frozen page. A no-op outside copy mode.
-    pub(crate) fn move_copy_mode_cursor(&mut self, motion: Motion) {
-        let Some(state) = &self.copy_mode else {
+    /// rows and the frozen page. The selection effect applies first, so
+    /// `Extend` anchors at the pre-move cursor — taking both here keeps
+    /// that ordering out of the caller's hands. A no-op outside copy
+    /// mode.
+    pub(crate) fn move_copy_mode_cursor(&mut self, motion: Motion, effect: SelectionEffect) {
+        let Some(state) = &mut self.copy_mode else {
             return;
         };
+        state.apply_selection_effect(effect);
         let rows = PaneRows {
             cache: state.cache(),
             grid: &self.grid,
@@ -422,7 +427,7 @@ fn clamp_viewport(current: u32, total: u32) -> ScrollbackClampOutcome {
 mod tests {
     use super::{PaneView, ScrollbackClampOutcome, clamp_viewport};
     use crate::copy_keys::{Motion, PendingPrefix};
-    use crate::copy_mode::{CopyModeState, CopySelectionType, FillRequest};
+    use crate::copy_mode::{CopyModeState, CopySelectionType, FillRequest, SelectionEffect};
     use crate::render_grid::ClientGrid;
     use oakterm_protocol::message::ScrollbackData;
     use oakterm_protocol::render::{DirtyRow, RenderUpdate, WireCell};
@@ -823,10 +828,10 @@ mod tests {
         view.enter_copy_mode();
         view.set_copy_mode_cursor(3, 0);
 
-        view.move_copy_mode_cursor(Motion::WordForward);
+        view.move_copy_mode_cursor(Motion::WordForward, SelectionEffect::Keep);
         assert_eq!(view.copy_mode().map(CopyModeState::cursor), Some((3, 6)));
 
-        view.move_copy_mode_cursor(Motion::LineEnd);
+        view.move_copy_mode_cursor(Motion::LineEnd, SelectionEffect::Keep);
         assert_eq!(view.copy_mode().map(CopyModeState::cursor), Some((3, 9)));
     }
 
@@ -848,7 +853,7 @@ mod tests {
         assert!(view.apply_copy_mode_scrollback(1, &data));
 
         view.set_copy_mode_cursor(-8, 0);
-        view.move_copy_mode_cursor(Motion::WordForward);
+        view.move_copy_mode_cursor(Motion::WordForward, SelectionEffect::Keep);
         assert_eq!(view.copy_mode().map(CopyModeState::cursor), Some((-8, 4)));
     }
 
@@ -881,7 +886,7 @@ mod tests {
         assert!(view.apply_copy_mode_scrollback(1, &data));
 
         view.set_copy_mode_cursor(-1, 0);
-        view.move_copy_mode_cursor(Motion::WordForward);
+        view.move_copy_mode_cursor(Motion::WordForward, SelectionEffect::Keep);
 
         assert_eq!(
             view.copy_mode().map(CopyModeState::cursor),
@@ -911,7 +916,7 @@ mod tests {
         );
 
         for _ in 0..7 {
-            view.move_copy_mode_cursor(Motion::HalfPageUp);
+            view.move_copy_mode_cursor(Motion::HalfPageUp, SelectionEffect::Keep);
         }
 
         assert_eq!(
@@ -936,11 +941,11 @@ mod tests {
         view.enter_copy_mode();
 
         view.set_copy_mode_cursor(0, 0);
-        view.move_copy_mode_cursor(Motion::PageUp);
+        view.move_copy_mode_cursor(Motion::PageUp, SelectionEffect::Keep);
         assert_eq!(view.copy_mode().map(CopyModeState::cursor), Some((0, 0)));
 
-        view.move_copy_mode_cursor(Motion::Bottom);
-        view.move_copy_mode_cursor(Motion::PageDown);
+        view.move_copy_mode_cursor(Motion::Bottom, SelectionEffect::Keep);
+        view.move_copy_mode_cursor(Motion::PageDown, SelectionEffect::Keep);
         assert_eq!(view.copy_mode().map(CopyModeState::cursor), Some((7, 0)));
     }
 
@@ -950,7 +955,7 @@ mod tests {
     fn copy_mode_commands_are_inert_outside_copy_mode() {
         let mut view = PaneView::new(ClientGrid::new(16, 8));
 
-        view.move_copy_mode_cursor(Motion::Down);
+        view.move_copy_mode_cursor(Motion::Down, SelectionEffect::Extend);
         view.toggle_copy_mode_selection(CopySelectionType::Character);
         view.set_copy_mode_pending_prefix(Some(PendingPrefix::G));
 
@@ -958,6 +963,21 @@ mod tests {
         assert_eq!(view.copy_mode_yank_range(), None);
         assert_eq!(view.copy_mode_pending_prefix(), None);
         assert!(!view.clear_copy_mode_selection());
+    }
+
+    /// `Extend` anchors before the motion resolves: the selection starts
+    /// at the pre-move cursor, not wherever the move lands.
+    #[test]
+    fn an_extending_move_anchors_at_the_pre_move_cursor() {
+        let mut view = PaneView::new(ClientGrid::new(16, 8));
+        view.enter_copy_mode();
+        view.set_copy_mode_cursor(3, 2);
+
+        view.move_copy_mode_cursor(Motion::Right, SelectionEffect::Extend);
+
+        let range = view.copy_mode_yank_range().expect("selecting");
+        assert_eq!((range.start_row, range.start_col), (3, 2));
+        assert_eq!((range.end_row, range.end_col), (3, 3));
     }
 
     /// Copy-mode state is per-pane, so a `g` armed on one pane cannot

--- a/docs/specs/0005-lua-config-runtime.md
+++ b/docs/specs/0005-lua-config-runtime.md
@@ -175,10 +175,10 @@ oakterm.config.oak_mod = "ctrl+shift"       -- Linux default; "super" on macOS (
 oakterm.config.leader = nil                  -- optional: { key = "ctrl+b", timeout = 1000 }
 oakterm.config.status_bar = true
 oakterm.config.status_bar_position = "bottom" -- "top" or "bottom"
+oakterm.config.copy_mode_keybinds = "vim"    -- "vim", "emacs", or "basic" (Spec-0008)
 
 -- NOT YET IMPLEMENTED. The current runtime treats unknown keys as hard errors,
--- so setting either key below raises a config error until its feature lands.
-oakterm.config.copy_mode_keybinds = "vim"    -- "vim", "emacs", or "basic" (ships with copy mode, TREK-112/113)
+-- so setting the key below raises a config error until its feature lands.
 oakterm.config.restartable_commands = {}     -- list of command prefixes to restore on session load (Spec-0010)
 ```
 

--- a/docs/specs/0008-copy-mode.md
+++ b/docs/specs/0008-copy-mode.md
@@ -41,9 +41,6 @@ struct CopyModeState {
 
     /// Active search state, if any.
     search: Option<SearchState>,
-
-    /// Which keybind preset is active.
-    preset: CopyModePreset,
 }
 
 struct CopySelection {
@@ -108,17 +105,15 @@ enum SearchDirection {
     Forward,
     Backward,
 }
-
-enum CopyModePreset {
-    Vim,
-    Emacs,
-    Basic,
-}
 ```
+
+The preset enum (`Vim`, `Emacs`, `Basic`) lives with the config surface as the value of `copy_mode_keybinds` (Spec-0005), not in per-pane state.
 
 ### Key Tables
 
-Copy mode activates a key table (ADR-0011). Unmatched keys are dropped, not forwarded to the PTY.
+Copy mode activates a key table (ADR-0011). Unmatched keys are dropped, not forwarded to the PTY. The active preset is `oakterm.config.copy_mode_keybinds` (Spec-0005), read at each key press rather than frozen into per-pane state at entry, so a config reload switches tables immediately.
+
+A configured leader chord outranks every preset row it collides with — ADR-0011 resolves the leader layer before the copy-mode table. With the template's suggested `leader = { key = "ctrl+b" }`, the vim preset's `Ctrl+b` (page up) and the emacs preset's `Ctrl+b` (cursor backward) arm the leader instead.
 
 #### Vim Preset (default)
 
@@ -153,38 +148,46 @@ Copy mode activates a key table (ADR-0011). Unmatched keys are dropped, not forw
 
 #### Emacs Preset
 
-| Key          | Action                                      |
-| ------------ | ------------------------------------------- |
-| `Ctrl+n`     | Cursor down                                 |
-| `Ctrl+p`     | Cursor up                                   |
-| `Ctrl+f`     | Cursor forward one character                |
-| `Ctrl+b`     | Cursor backward one character               |
-| `Alt+f`      | Cursor to next word                         |
-| `Alt+b`      | Cursor to previous word                     |
-| `Ctrl+a`     | Cursor to start of line                     |
-| `Ctrl+e`     | Cursor to end of line                       |
-| `Alt+<`      | Cursor to top of scrollback                 |
-| `Alt+>`      | Cursor to bottom                            |
-| `Ctrl+v`     | Page down                                   |
-| `Alt+v`      | Page up                                     |
-| `Ctrl+Space` | Start/toggle selection                      |
-| `Alt+w`      | Yank selection to clipboard, exit copy mode |
-| `Ctrl+g`     | Exit copy mode                              |
-| `Ctrl+s`     | Start forward search                        |
-| `Ctrl+r`     | Start backward search                       |
+| Key          | Action                                                |
+| ------------ | ----------------------------------------------------- |
+| `Ctrl+n`     | Cursor down                                           |
+| `Ctrl+p`     | Cursor up                                             |
+| `Ctrl+f`     | Cursor forward one character                          |
+| `Ctrl+b`     | Cursor backward one character                         |
+| `Alt+f`      | Cursor to next word end                               |
+| `Alt+b`      | Cursor to previous word start                         |
+| `Ctrl+a`     | Cursor to start of line                               |
+| `Ctrl+e`     | Cursor to end of line                                 |
+| `Alt+<`      | Cursor to top of scrollback                           |
+| `Alt+>`      | Cursor to bottom                                      |
+| `Ctrl+v`     | Page down                                             |
+| `Alt+v`      | Page up                                               |
+| `Ctrl+Space` | Start/toggle selection                                |
+| `Alt+w`      | Yank selection to clipboard, exit copy mode           |
+| `Ctrl+g`     | Exit copy mode                                        |
+| `Escape`     | Exit copy mode (clear selection if active, else exit) |
+| `Ctrl+s`     | Start forward search                                  |
+| `Ctrl+r`     | Start backward search                                 |
+
+`Alt+f` lands on the last character of the word, matching tmux's emacs
+copy mode (`next-word-end`) rather than emacs's point-after-word. `Escape`
+follows the vim row's clear-then-exit shape so every preset keeps a
+universal way out.
 
 #### Basic Preset
 
-| Key                                                      | Action                                      |
-| -------------------------------------------------------- | ------------------------------------------- |
-| `Up` / `Down` / `Left` / `Right`                         | Cursor movement                             |
-| `Page Up` / `Page Down`                                  | Page movement                               |
-| `Home`                                                   | Top of scrollback                           |
-| `End`                                                    | Bottom                                      |
-| `Shift+Up` / `Shift+Down` / `Shift+Left` / `Shift+Right` | Extend selection                            |
-| `Ctrl+c`                                                 | Copy selection to clipboard, exit copy mode |
-| `Escape`                                                 | Exit copy mode                              |
-| `Ctrl+f`                                                 | Start search                                |
+| Key                                                      | Action                                                |
+| -------------------------------------------------------- | ----------------------------------------------------- |
+| `Up` / `Down` / `Left` / `Right`                         | Cursor movement                                       |
+| `Page Up` / `Page Down`                                  | Page movement                                         |
+| `Home`                                                   | Top of scrollback                                     |
+| `End`                                                    | Bottom                                                |
+| `Shift+Up` / `Shift+Down` / `Shift+Left` / `Shift+Right` | Extend selection                                      |
+| `Ctrl+c`                                                 | Copy selection to clipboard, exit copy mode           |
+| `Escape`                                                 | Exit copy mode (clear selection if active, else exit) |
+| `Ctrl+f`                                                 | Start search                                          |
+
+Unshifted movement clears an active selection before moving; any shifted movement extends one, anchoring at the cursor if none is active. This is the GUI convention the preset mirrors — a plain arrow deselects, `Shift+Page Down` selects a page from a bare caret.
 
 ### Protocol Messages
 


### PR DESCRIPTION
## Summary

Implements TREK-113: the emacs and basic copy-mode key tables from Spec-0008 join the vim table shipped in #56, selected by the new `oakterm.config.copy_mode_keybinds` key (`"vim"` / `"emacs"` / `"basic"`, default vim).

- **Config**: `copy_mode_keybinds` through schema validation, proxy extraction, LLS stubs, and the config template. Read at each key press rather than frozen at copy-mode entry, so a config reload switches tables immediately — verified live mid-copy-mode.
- **Classification**: `CopyKey` gains Alt chords (composed character preferred; base-key fallback where macOS Option composition hides the letter, with a shift-recovery pattern so `M-<`/`M->` survive) and named navigation keys with shift state. Ctrl+Space classifies via winit's named Space.
- **Selection policy as data**: `CopyCommand::Move { motion, selection: SelectionEffect }` — vim/emacs keep the selection, basic extends on shifted navigation and clears on unshifted (GUI convention), Escape clears before exiting in every preset. The effect applies inside `PaneView::move_copy_mode_cursor` before the motion resolves, so Extend's pre-move anchor is structural.
- **Spec-0008 amendments**: emacs Escape row, `Alt+f` as word end (tmux `next-word-end`), basic-preset selection semantics prose, leader-chord-outranks-preset-rows note (tmux/screen precedent), preset enum moved out of per-pane state.

Search keys are consumed but inert until the TREK-114 overlay; direction is re-introduced at the table layer there (noted on TREK-114).

## Verification

- Two full review cycles this session (6 fan-out iterations; Codex clean on every leg; all findings fixed inline).
- 405 + 207 unit tests, full workspace suite 1573 green; clippy pedantic, fmt, rumdl clean.
- Live smoke test on macOS: both presets driven end-to-end in the real GUI — basic (Home, Shift+Down, Ctrl+c → clipboard) and emacs (`M-<` via the Option-composition recovery path, Ctrl+Space, Ctrl+n, `M-w` → clipboard), plus hot-reload preset switching while copy mode was open.

TREK-113