### PR TITLE
docs(ideas): record Wave prior art from the 2026-08 research pass

### DIFF
--- a/docs/ideas/11-inspiration.md
+++ b/docs/ideas/11-inspiration.md
@@ -87,8 +87,8 @@ What we took from each terminal and tool — and what we deliberately left out.
 
 ### Wave
 
-**Took:** Proves users want inline file previews and that a terminal can embed non-terminal content in panes
-**Left:** Drag-and-drop workspace model, built-in editor, too many concerns in one app
+**Took:** Proves users want inline file previews and that a terminal can embed non-terminal content in panes. `wsh` CLI verb space validates the [`oakterm ctl` design](32-agent-control-api.md) and names verbs it lacks. Durable sessions validate the remote reattach model ([remote access](29-remote-access.md)). Sysinfo and process-viewer widgets prove demand for the process dashboard. Apache-2.0, so mechanisms are borrowable, unlike Warp's AGPL.
+**Left:** Drag-and-drop workspace model, built-in editor, too many concerns in one app. Electron + xterm.js stack — VT parsing in the renderer, reported high memory usage, TUI redraw glitches from missing synchronized-output support. Go→TS codegen keeping client and server in build-time lockstep instead of a versioned wire format. Block-first paradigm. Alt-screen content unreachable after TUI exit ([wavetermdev/waveterm#2837](https://github.com/wavetermdev/waveterm/issues/2837)) — the problem class our copy-mode work solves.
 
 ### Tamux
 

--- a/docs/ideas/29-remote-access.md
+++ b/docs/ideas/29-remote-access.md
@@ -238,6 +238,8 @@ The remote connection is too deep to be a plugin:
 
 ## Prior Art
 
+Wave's [durable sessions](https://docs.waveterm.dev/durable-sessions) (v0.14) are the closest shipped implementation of this doc's model from the opposite direction: a lightweight Go job manager on the remote host keeps the shell and its children alive independently of the client, buffers output over a Unix domain socket, and reattaches after network drops, sleep, or app restart. Version-check and launch of the remote helper share one SSH session on the steady-state path; an install round trip is added only when the helper is older than the client. Wave prompts before installing by default (`conn:askbeforewshinstall`) and offers an opt-in to silent install across all connections; worth matching, with per-host rather than global consent.
+
 Remote steering of long-running agent sessions is the strongest converged demand in the 2026 agent-tooling wave: Zeron ships a single binary with headed/headless modes and phone clients that watch and steer desktop sessions; ZCode's Bot Channel monitors Goals from WeChat/Telegram; Orca ships a mobile companion app. Zeron's mobile clients are monitor-first with opt-in interaction — the same default as `remote_allow_interactive = false` here. Zeron reached this architecture by rewriting an Electron app from scratch; oakterm's daemon/client split provides it natively. See the [Agent Tooling Landscape Audit](../reviews/2026-08-16-215731-agent-tooling-landscape-audit.md).
 
 ## Related Docs

--- a/docs/ideas/32-agent-control-api.md
+++ b/docs/ideas/32-agent-control-api.md
@@ -268,6 +268,13 @@ oakterm ctl pane create --floating --command "docker compose up" --title "Docker
 oakterm ctl notify "Dev environment ready"
 ```
 
+## Prior Art
+
+**[Wave](https://docs.waveterm.dev/wsh-reference)** — its `wsh` CLI is the same design shipped: a single verb space letting shell scripts and agents drive GUI state over the daemon socket with no protocol knowledge (`setmeta`, `notify`, `badge`, `run`, `termscrollback`). Its [Claude Code integration](https://docs.waveterm.dev/claude-code) is lifecycle hooks calling `wsh badge` — a plain CLI covering agent integration without MCP. Two verbs it has that this surface lacks, both candidates:
+
+- `getvar`/`setvar` — persistent key-value variables scoped to block, tab, workspace, or client-wide, giving scripts cross-session state without a dotfile
+- `secret` — OS-keychain-backed credential storage (get/set/list/delete), so scripts never keep tokens in plaintext
+
 ## What This Is Not
 
 - Not an MCP server — it's a CLI. No protocol beyond "run a command, get output."


### PR DESCRIPTION
## Summary

Records the Wave (wavetermdev/waveterm) prior-art research into the idea docs where each mechanism lands:

- **`11-inspiration.md`** — the Wave entry grows from two lines to a full took/left picture: `wsh` CLI validation, durable sessions, process-widget demand, Apache-2.0 borrowability; left: Electron/xterm.js stack, codegen-lockstep protocol, block-first paradigm, alt-screen scrollback loss ([wavetermdev/waveterm#2837](https://github.com/wavetermdev/waveterm/issues/2837)).
- **`29-remote-access.md`** — prior-art paragraph on [durable sessions](https://docs.waveterm.dev/durable-sessions) (v0.14): remote job manager surviving disconnects, steady-state single-SSH-session bootstrap with older-than upgrade, prompt-by-default helper install worth matching with per-host consent.
- **`32-agent-control-api.md`** — Prior Art section on the [`wsh` CLI](https://docs.waveterm.dev/wsh-reference) as the same shipped design, naming `getvar`/`setvar` (scoped persistent KV) and `secret` (keychain-backed credentials) as candidate verbs `oakterm ctl` lacks.

## Verification

Claims went through a review cycle with live source checks: issue #2837 title/body, LICENSE (Apache-2.0), the durable-sessions and wsh-reference docs pages, and Wave's connection-controller source were fetched during review. One research claim was refuted and corrected — Wave prompts before installing its remote helper by default (`conn:askbeforewshinstall: true`); silent install is opt-in. Six unverifiable claims (memory figures, quoted complaints, snapshot-replay internals) were removed rather than shipped.

`mise run fmt` and `mise run lint` clean.